### PR TITLE
use direct UART register accesses and disabled interrupts

### DIFF
--- a/NeoPixelBus.cpp
+++ b/NeoPixelBus.cpp
@@ -123,12 +123,6 @@ void NeoPixelBus::Show(void)
     uint8_t* p = _pixels;
     uint8_t* end = p + _sizePixels;
 
-    // in case of blocking transfers, make sure no other interrupt is causing jitter
-    if(IsBlocking())
-    {
-        noInterrupts();
-    }
-    
     do
     {
         uint8_t subpix = *p++;
@@ -138,8 +132,8 @@ void NeoPixelBus::Show(void)
         buff[2] = _uartData[(subpix >> 2) & 3];
         buff[3] = _uartData[subpix & 3];
 
-        // for blocking transfers, directly access UART, else use library
-        if(IsBlocking())
+        // if configured, directly access UART
+        if(isDirect())
         {
             for(int pos = 0; pos < 4; pos++)
             {
@@ -151,12 +145,6 @@ void NeoPixelBus::Show(void)
             Serial1.write(buff, sizeof(buff));
         }
     } while (p < end);
-
-    // recover interrupt state
-    if(IsBlocking())
-    {
-        interrupts();
-    }
     
     ResetDirty();
     _endTime = micros(); // Save EOD time for latch on next call

--- a/NeoPixelBus.cpp
+++ b/NeoPixelBus.cpp
@@ -111,7 +111,8 @@ void NeoPixelBus::Show(void)
     uint8_t* p = _pixels;
     uint8_t* end = p + _sizePixels;
 
-
+    noInterrupts();
+    
     do
     {
         uint8_t subpix = *p++;
@@ -120,10 +121,15 @@ void NeoPixelBus::Show(void)
         buff[1] = _uartData[(subpix >> 4) & 3];
         buff[2] = _uartData[(subpix >> 2) & 3];
         buff[3] = _uartData[subpix & 3];
-        Serial1.write(buff, sizeof(buff));
+
+        U1F = buff[0]; while(((U1S >> USTXC) & 0xff));
+        U1F = buff[1]; while(((U1S >> USTXC) & 0xff));
+        U1F = buff[2]; while(((U1S >> USTXC) & 0xff));
+        U1F = buff[3]; while(((U1S >> USTXC) & 0xff));
 
     } while (p < end);
 
+    interrupts();
     ResetDirty();
     _endTime = micros(); // Save EOD time for latch on next call
 }

--- a/NeoPixelBus.cpp
+++ b/NeoPixelBus.cpp
@@ -123,6 +123,11 @@ void NeoPixelBus::Show(void)
     uint8_t* p = _pixels;
     uint8_t* end = p + _sizePixels;
 
+    if(isDirectNoInts())
+    {
+        noInterrupts();
+    }
+    
     do
     {
         uint8_t subpix = *p++;
@@ -145,6 +150,11 @@ void NeoPixelBus::Show(void)
             Serial1.write(buff, sizeof(buff));
         }
     } while (p < end);
+    
+    if(isDirectNoInts())
+    {
+        interrupts();
+    }
     
     ResetDirty();
     _endTime = micros(); // Save EOD time for latch on next call

--- a/NeoPixelBus.h
+++ b/NeoPixelBus.h
@@ -39,6 +39,7 @@ enum ColorType
 #define NEO_KHZ400  0x00 // 400 KHz datastream
 #define NEO_KHZ800  0x02 // 800 KHz datastream
 #define NEO_SPDMASK 0x02
+#define NEO_BLOCK   0x08 // use blocking transfer to reduce impact of WiFi interrupts
 #define NEO_DIRTY   0x80 // a change was made it _pixels that requires a show
 
 // v1 NeoPixels aren't handled by default, include the following define before the 
@@ -71,6 +72,10 @@ public:
         ClearTo(c.R, c.G, c.B);
     }
 
+    bool IsBlocking() const
+    {
+        return  (_flagsPixels & NEO_BLOCK);
+    };
     bool IsDirty() const
     {
         return  (_flagsPixels & NEO_DIRTY);
@@ -104,6 +109,7 @@ public:
 private:
     friend NeoPixelAnimator;
 
+    void SendByte(uint8_t data);
     void UpdatePixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b);
     void UpdatePixelColor(uint16_t n, RgbColor c)
     {

--- a/NeoPixelBus.h
+++ b/NeoPixelBus.h
@@ -40,6 +40,7 @@ enum ColorType
 #define NEO_KHZ800  0x02 // 800 KHz datastream
 #define NEO_SPDMASK 0x02
 #define NEO_DIRECT  0x08 // directly access UART registers for xfer instead of using library routines that might yield
+#define NEO_DNOINTS 0x18 // directly access and disable interrupts
 #define NEO_DIRTY   0x80 // a change was made it _pixels that requires a show
 
 // v1 NeoPixels aren't handled by default, include the following define before the 
@@ -72,6 +73,10 @@ public:
         ClearTo(c.R, c.G, c.B);
     }
 
+    bool isDirectNoInts() const
+    {
+        return (_flagsPixels & NEO_DNOINTS) == NEO_DNOINTS;
+    };
     bool isDirect() const
     {
         return  (_flagsPixels & NEO_DIRECT);

--- a/NeoPixelBus.h
+++ b/NeoPixelBus.h
@@ -39,7 +39,7 @@ enum ColorType
 #define NEO_KHZ400  0x00 // 400 KHz datastream
 #define NEO_KHZ800  0x02 // 800 KHz datastream
 #define NEO_SPDMASK 0x02
-#define NEO_BLOCK   0x08 // use blocking transfer to reduce impact of WiFi interrupts
+#define NEO_DIRECT   0x08 // use blocking transfer to reduce impact of WiFi interrupts
 #define NEO_DIRTY   0x80 // a change was made it _pixels that requires a show
 
 // v1 NeoPixels aren't handled by default, include the following define before the 
@@ -72,9 +72,9 @@ public:
         ClearTo(c.R, c.G, c.B);
     }
 
-    bool IsBlocking() const
+    bool isDirect() const
     {
-        return  (_flagsPixels & NEO_BLOCK);
+        return  (_flagsPixels & NEO_DIRECT);
     };
     bool IsDirty() const
     {

--- a/NeoPixelBus.h
+++ b/NeoPixelBus.h
@@ -39,7 +39,7 @@ enum ColorType
 #define NEO_KHZ400  0x00 // 400 KHz datastream
 #define NEO_KHZ800  0x02 // 800 KHz datastream
 #define NEO_SPDMASK 0x02
-#define NEO_DIRECT   0x08 // use blocking transfer to reduce impact of WiFi interrupts
+#define NEO_DIRECT  0x08 // directly access UART registers for xfer instead of using library routines that might yield
 #define NEO_DIRTY   0x80 // a change was made it _pixels that requires a show
 
 // v1 NeoPixels aren't handled by default, include the following define before the 


### PR DESCRIPTION
This patch allows both WiFi and WS2812 to work without any flicker or crashes.