### PR TITLE
Add library.json for platformio support

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,14 @@
+{
+  "name": "NeoPixelBus",
+  "description": "Adafruit enhanced NeoPixel support library",
+  "keywords": "WS2811,WS2812,ESP8266",
+  "frameworks": "*",
+  "platforms": "*",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Makuna/NeoPixelBus.git"
+  },
+  "examples": [
+    "examples/*/*.pde"
+  ]
+}


### PR DESCRIPTION
I've added a library.json file so this library is detectable with platformio.

Would love to see this project in the platformio repository. I've been trying it out just now, and it seems very convenient (i'm not affiliated with platformio in any way, by the way).

Not too sure how this would work out with the different branches though, I don't think the library.json file format has branch support yet.