### PR TITLE
Fix malformed first pulses

### DIFF
--- a/NeoPixelBus.h
+++ b/NeoPixelBus.h
@@ -109,17 +109,6 @@ private:
     {
         UpdatePixelColor(n, c.R, c.G, c.B);
     };
-    inline void UartSendByte(uint8_t data)
-    {
-        // directly write the byte to transfer into the UART1 FIFO register
-        U1F = data;
-
-        // now wait till this the FIFO buffer is emtpy
-        while (((U1S >> USTXC) & 0xff) != 0x00)
-        {
-            // do nothing, just wait
-        }
-    }
 
     const uint16_t    _countPixels;     // Number of RGB LEDs in strip
     const uint16_t    _sizePixels;      // Size of '_pixels' buffer below
@@ -127,7 +116,5 @@ private:
     uint8_t _flagsPixels;    // Pixel flags (400 vs 800 KHz, RGB vs GRB color)
     uint8_t* _pixels;        // Holds LED color values (3 bytes each)
     uint32_t _endTime;       // Latch timing reference
-
-    const char _uartData[4] = { 0b00110111, 0b00000111, 0b00110100, 0b00000100 };
 };
 

--- a/NeoPixelEsp8266.c
+++ b/NeoPixelEsp8266.c
@@ -1,0 +1,41 @@
+/*
+NeoPixelEsp8266.c - NeoPixel library helper functions for Esp8266 using cycle count
+Copyright (c) 2015 Michael C. Miller. All right reserved.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include <Arduino.h>
+#include <eagle_soc.h>
+
+void ICACHE_RAM_ATTR esp8266_uart1_send_pixels(uint8_t* pixels, uint8_t* end)
+{
+    const char _uartData[4] = { 0b00110111, 0b00000111, 0b00110100, 0b00000100 };
+
+    do
+    {
+        uint8_t subpix = *pixels++;
+
+        // now wait till this the FIFO buffer is emtpy
+        while (((U1S >> USTXC) & 0xff) != 0x00);
+
+        // directly write the byte to transfer into the UART1 FIFO register
+        U1F = _uartData[(subpix >> 6) & 3];
+        U1F = _uartData[(subpix >> 4) & 3];
+        U1F = _uartData[(subpix >> 2) & 3];
+        U1F = _uartData[subpix & 3];
+    } while (pixels < end);
+}
+


### PR DESCRIPTION
Due to the send routine not being in RAM, it would cause strange first
pulse inconsistencies.  This solution was original discovered with the
CycleCount BitBang solution and was thought unneeded for the Uart
version, but I discovered that it was still a problem and brought the
solution back.