### PR TITLE
Better Uart FiFo buffer use and fix minimum delay between sends

### DIFF
--- a/NeoPixelBus.h
+++ b/NeoPixelBus.h
@@ -39,6 +39,7 @@ enum ColorType
 #define NEO_KHZ400  0x00 // 400 KHz datastream
 #define NEO_KHZ800  0x02 // 800 KHz datastream
 #define NEO_SPDMASK 0x02
+#define NEO_IRQLOCK 0x40 // IRQs will be locked on uart fifo writing
 #define NEO_DIRTY   0x80 // a change was made it _pixels that requires a show
 
 // v1 NeoPixels aren't handled by default, include the following define before the 
@@ -63,7 +64,16 @@ public:
     void Show();
     inline bool CanShow(void) const
     { 
-        return (micros() - _endTime) >= 50L; 
+        uint32_t delta = micros() - _endTime;
+        uint32_t usPixelTime = _usPixelTime800mhz;
+
+#ifdef INCLUDE_NEO_KHZ400_SUPPORT
+        if ((_flagsPixels & NEO_SPDMASK) == NEO_KHZ400)
+        {
+            usPixelTime = _usPixelTime400mhz;
+        }
+#endif
+        return (delta >= 50L && delta <= (4294967296L - (usPixelTime * _countPixels)));
     }
     void ClearTo(uint8_t r, uint8_t g, uint8_t b);
     void ClearTo(RgbColor c)
@@ -84,6 +94,10 @@ public:
         _flagsPixels &= ~NEO_DIRTY;
     }
 
+    bool IsIrqLocking() const
+    {
+        return  (_flagsPixels & NEO_IRQLOCK);
+    };
     uint8_t* Pixels() const
     {
         return _pixels;
@@ -110,6 +124,10 @@ private:
         UpdatePixelColor(n, c.R, c.G, c.B);
     };
 
+    const uint32_t _usPixelTime800mhz = 30; // us it takes to send a single pixel at 800mhz speed
+#ifdef INCLUDE_NEO_KHZ400_SUPPORT
+    const uint32_t _usPixelTime400mhz = 60; // us it takes to send a single pixel at 800mhz speed
+#endif
     const uint16_t    _countPixels;     // Number of RGB LEDs in strip
     const uint16_t    _sizePixels;      // Size of '_pixels' buffer below
     

--- a/NeoPixelEsp8266.c
+++ b/NeoPixelEsp8266.c
@@ -20,22 +20,39 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <Arduino.h>
 #include <eagle_soc.h>
 
-void ICACHE_RAM_ATTR esp8266_uart1_send_pixels(uint8_t* pixels, uint8_t* end)
+void ICACHE_RAM_ATTR esp8266_uart1_send_pixels(uint8_t* pixels, uint8_t* end, bool isIrqLocking)
 {
-    const char _uartData[4] = { 0b00110111, 0b00000111, 0b00110100, 0b00000100 };
+    const uint8_t _uartData[4] = { 0b00110111, 0b00000111, 0b00110100, 0b00000100 };
+    const uint8_t _uartFifoTrigger = 124; // tx fifo should be 128 bytes. minus the four we need to send
 
     do
     {
         uint8_t subpix = *pixels++;
+        uint8_t buf[4] = { _uartData[(subpix >> 6) & 3], 
+            _uartData[(subpix >> 4) & 3], 
+            _uartData[(subpix >> 2) & 3], 
+            _uartData[subpix & 3] };
+        uint32_t savedPS;
 
-        // now wait till this the FIFO buffer is emtpy
-        while (((U1S >> USTXC) & 0xff) != 0x00);
+        // now wait till this the FIFO buffer has room to send more
+        while (((U1S >> USTXC) & 0xff) > _uartFifoTrigger);
 
-        // directly write the byte to transfer into the UART1 FIFO register
-        U1F = _uartData[(subpix >> 6) & 3];
-        U1F = _uartData[(subpix >> 4) & 3];
-        U1F = _uartData[(subpix >> 2) & 3];
-        U1F = _uartData[subpix & 3];
+        if (isIrqLocking)
+        {
+            savedPS = xt_rsil(15); // stop other interrupts
+        }
+
+        for (uint8_t i = 0; i < 4; i++)
+        {
+            // directly write the byte to transfer into the UART1 FIFO register
+            U1F = buf[i];
+        }
+
+        if (isIrqLocking)
+        {
+            xt_wsr_ps(savedPS); // reenable other interrupts
+        }
+
     } while (pixels < end);
 }
 


### PR DESCRIPTION
Only wait when there is no room in the uart buffer
Correctly wait between updates for the minimum latch time in case the
caller is updating as fast as they can
Expose the ability to turn on IRQ locking (this is experimental feature)