### PR TITLE
Fix wrong value for NEO_COLMASK

### DIFF
--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -32,7 +32,7 @@ License along with NeoPixel.  If not, see
 #define NEO_RGB     0x00 // Wired for RGB data order
 #define NEO_GRB     0x01 // Wired for GRB data order
 #define NEO_BRG     0x02
-#define NEO_COLMASK 0x08 // which bits are used for the color order flags
+#define NEO_COLMASK 0x03 // which bits are used for the color order flags
 
 #define NEO_KHZ400  0x10 // 400 KHz datastream
 #define NEO_KHZ800  0x00 // 800 KHz datastream (default)


### PR DESCRIPTION
ed64ec04 changed the NEO_GBR flag from 0x04 to 0x02 and NEO_COLMASK from 0x05 to 0x08. That value for COLMASK is wrong though.
The purpose of the mask is to only select the bits we want.

The options NEO_RGB, NEO_GRB and NEO_BRG occupy the lower 3 bits.
The correct mask for that is 00000011 -> 0x03.
0x08 would select none of the color bits currently available, defaulting the strip to NEO_RGB mode.