### PR TITLE
Ported Arm Support

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,14 +4,17 @@
 
 Arduino NeoPixel library
 
-Please read this best practices link before connecting your NeoPixels, it will save you alot of time and effort. [AdaFruits NeoPixel Best Practices](https://learn.adafruit.com/adafruit-neopixel-uberguide/best-practices)
+A library to control one wire protocol RGB leds like SK6812, WS2811, and WS2812 that are commonly refered to as NeoPixels.
 
-This version currently only supports AVR and Esp8266.  Other platforms can be supported by creating an issue on GitHub/Makuna/NeoPixelBus.  
+Please read this best practices link before connecting your NeoPixels, it will save you alot of time and effort.  
+[AdaFruits NeoPixel Best Practices](https://learn.adafruit.com/adafruit-neopixel-uberguide/best-practices)
 
-NOW SUPPORTS RGBW! 
-SK6812, WS2811, and WS2812 are usable with this library.
+For quick questions jump on Gitter and ask away.  
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Makuna/NeoPixelBus?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-The new library supports a templatized model of defining which method gets used to send data and what order and size the pixel data is sent in.  This new design creates the smallest code for each definition of features used.  Please see examples to become familiar with the new design.
+For bugs, make sure there isn't an active issue and then create one.
+
+This new library supports a templatized model of defining which method gets used to send data and what order and size the pixel data is sent in.  This new design creates the smallest code for each definition of features used.  Please see examples to become familiar with the new design.
 
 Using the StandTest example from AdaFruit_NeoPixel library targeting a Arduino Mega 2560 as a comparison, you can see the compilation results below.
 
@@ -26,30 +29,14 @@ NeoPixelBus library
 Sketch uses 3,570 bytes (1%) of program storage space. Maximum is 253,952 bytes.
 Global variables use 34 bytes (0%) of dynamic memory, leaving 8,158 bytes for local variables. Maximum is 8,192 bytes.
 ```
-## Requirements
 
-Due to the use of hardware or software features of each method, there are implications that you need to understand.  Please review the methods for more understanding of the tradeoffs.
-
-## Installing This Library
+## Installing This Library (prefered)
 Open the Library Manager and search for "NeoPixelBus by Makuna" and install
 
 ## Installing This Library From GitHub
 Create a directory in your Arduino\Library folder named "NeoPixelBus"
 Clone (Git) this project into that folder.  
 It should now show up in the import list when you restart Arduino IDE.
-
-## Samples
-### NeoPixelTest
-This is a good place to start and make sure your pixels work.
-This is simple example that sets four pixels to red, green, blue, and white in order; and then flashes off and then on again.  If the first pixel is green and the second is red, you need to use the NeoRgbFeature with NeoPixelBus constructor.
-### NeoPixelFunLoop
-This example will move a trail of light around a series of pixels with a fading tail. A ring formation of pixels looks best.
-### NeoPixelFunRandomChange
-This example will randomly select a number pixels and then start an animation to blend them from their current color to randomly selected a color.
-### NeoPixelFunFadeInOut
-This example will randomly pick a color and fade all pixels to that color, then it will fade them to black and restart over.
-### NeoPixelAnimation
-This is a more complex example that demonstrates platform specific animation callbacks and the timescale support for long duration animations.
 
 ## Documentation
 [See Wiki](https://github.com/Makuna/NeoPixelBus/wiki)

--- a/examples/NeoPixelAnimation/NeoPixelAnimation.ino
+++ b/examples/NeoPixelAnimation/NeoPixelAnimation.ino
@@ -21,16 +21,14 @@
 const uint16_t PixelCount = 4; // make sure to set this to the number of pixels in your strip
 const uint8_t PixelPin = 2;  // make sure to set this to the correct pin, ignored for UartDriven branch
 
-#ifdef ARDUINO_ARCH_AVR
-NeoPixelBus<NeoGrbFeature, NeoAvr800KbpsMethod> strip(PixelCount, PixelPin);
-#elif ARDUINO_ARCH_ESP8266
-NeoPixelBus<NeoGrbFeature, NeoEsp8266Dma800KbpsMethod> strip(PixelCount, PixelPin);
-#else
-#error "Platform Currently Not Supported"
-#endif
+NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+// Other Esp8266 alternative methods
+//NeoPixelBus<NeoGrbFeature, NeoEsp8266Uart800KbpsMethod> strip(PixelCount, PixelPin);
+//NeoPixelBus<NeoGrbFeature, NeoEsp8266BitBang800KbpsMethod> strip(PixelCount, PixelPin);
 
 // NeoPixel animation time management object
 NeoPixelAnimator animations(PixelCount, NEO_CENTISECONDS);
+
 // create with enough animations to have one per pixel, depending on the animation
 // effect, you may need more or less.
 //
@@ -52,6 +50,8 @@ NeoPixelAnimator animations(PixelCount, NEO_CENTISECONDS);
 
 #ifdef ARDUINO_ARCH_AVR
 // for AVR, you need to manage the state due to lack of STL/compiler support
+// for Esp8266 you can define the function using a lambda and state is created for you
+// see below for an example
 struct MyAnimationState
 {
     RgbColor StartingColor;

--- a/examples/NeoPixelFunFadeInOut/NeoPixelFunFadeInOut.ino
+++ b/examples/NeoPixelFunFadeInOut/NeoPixelFunFadeInOut.ino
@@ -12,13 +12,7 @@ const uint16_t PixelCount = 16; // make sure to set this to the number of pixels
 const uint8_t PixelPin = 2;  // make sure to set this to the correct pin, ignored for UartDriven branch
 const uint8_t AnimationChannels = 1; // we only need one as all the pixels are animated at once
 
-#ifdef ARDUINO_ARCH_AVR
-NeoPixelBus<NeoGrbFeature, NeoAvr800KbpsMethod> strip(PixelCount, PixelPin);
-#elif ARDUINO_ARCH_ESP8266
-NeoPixelBus<NeoGrbFeature, NeoEsp8266Dma800KbpsMethod> strip(PixelCount, PixelPin);
-#else
-#error "Platform Currently Not Supported"
-#endif
+NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
 
 NeoPixelAnimator animations(AnimationChannels); // NeoPixel animation management object
 

--- a/examples/NeoPixelFunLoop/NeoPixelFunLoop.ino
+++ b/examples/NeoPixelFunLoop/NeoPixelFunLoop.ino
@@ -23,13 +23,7 @@ const uint16_t PixelFadeDuration = 400; // half a second
 // one second divide by the number of pixels = loop once a second
 const uint16_t NextPixelMoveDuration = 1000 / PixelCount; // how fast we move through the pixels
 
-#ifdef ARDUINO_ARCH_AVR
-NeoPixelBus<NeoGrbFeature, NeoAvr800KbpsMethod> strip(PixelCount, PixelPin);
-#elif ARDUINO_ARCH_ESP8266
-NeoPixelBus<NeoGrbFeature, NeoEsp8266Dma800KbpsMethod> strip(PixelCount, PixelPin);
-#else
-#error "Platform Currently Not Supported"
-#endif
+NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
 
 // what is stored for state is specific to the need, in this case, the colors and
 // the pixel to animate;

--- a/examples/NeoPixelFunRandomChange/NeoPixelFunRandomChange.ino
+++ b/examples/NeoPixelFunRandomChange/NeoPixelFunRandomChange.ino
@@ -10,13 +10,7 @@
 const uint16_t PixelCount = 16; // make sure to set this to the number of pixels in your strip
 const uint8_t PixelPin = 2;  // make sure to set this to the correct pin, ignored for UartDriven branch
 
-#ifdef ARDUINO_ARCH_AVR
-NeoPixelBus<NeoGrbFeature, NeoAvr800KbpsMethod> strip(PixelCount, PixelPin);
-#elif ARDUINO_ARCH_ESP8266
-NeoPixelBus<NeoGrbFeature, NeoEsp8266Dma800KbpsMethod> strip(PixelCount, PixelPin);
-#else
-#error "Platform Currently Not Supported"
-#endif
+NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
 
 NeoPixelAnimator animations(PixelCount); // NeoPixel animation management object
 

--- a/examples/NeoPixelTest/NeoPixelTest.ino
+++ b/examples/NeoPixelTest/NeoPixelTest.ino
@@ -19,25 +19,27 @@ const uint8_t PixelPin = 2;  // make sure to set this to the correct pin, ignore
 #define colorSaturation 128
 
 // three element pixels, in different order and speeds
-NeoPixelBus<NeoGrbFeature, NeoAvr800KbpsMethod> strip(PixelCount, PixelPin);
-//NeoPixelBus<NeoRgbFeature, NeoAvr400KbpsMethod> strip(PixelCount, PixelPin);
+NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+//NeoPixelBus<NeoRgbFeature, Neo400KbpsMethod> strip(PixelCount, PixelPin);
 
-// Use one of these for Esp8266
+// You can also use one of these for Esp8266, 
+// each having their own restrictions
+//
+// These two are the same as above as the DMA method is the default
 //NeoPixelBus<NeoGrbFeature, NeoEsp8266Dma800KbpsMethod> strip(PixelCount, PixelPin);
 //NeoPixelBus<NeoRgbFeature, NeoEsp8266Dma400KbpsMethod> strip(PixelCount, PixelPin);
 
+// Uart method is good for the Esp-01 or other pin restricted modules
 //NeoPixelBus<NeoGrbFeature, NeoEsp8266Uart800KbpsMethod> strip(PixelCount, PixelPin);
 //NeoPixelBus<NeoRgbFeature, NeoEsp8266Uart400KbpsMethod> strip(PixelCount, PixelPin);
 
+// The bitbang method is really only good if you are not using WiFi features of the ESP
+// It has no pin restrictions.
 //NeoPixelBus<NeoGrbFeature, NeoEsp8266BitBang800KbpsMethod> strip(PixelCount, PixelPin);
 //NeoPixelBus<NeoRgbFeature, NeoEsp8266BitBang400KbpsMethod> strip(PixelCount, PixelPin);
 
-
 // four element pixels, RGBW
-//NeoPixelBus<NeoRgbwFeature, NeoAvr800KbpsMethod> strip(PixelCount, PixelPin);
-//NeoPixelBus<NeoRgbwFeature, NeoEsp8266Dma800KbpsMethod> strip(PixelCount, PixelPin);
-//NeoPixelBus<NeoRgbwFeature, NeoEsp8266Uart800KbpsMethod> strip(PixelCount, PixelPin);
-//NeoPixelBus<NeoRgbwFeature, NeoEsp8266BitBang800KbpsMethod> strip(PixelCount, PixelPin);
+//NeoPixelBus<NeoRgbwFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
 
 RgbColor red(colorSaturation, 0, 0);
 RgbColor green(0, colorSaturation, 0);

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=A library that makes controlling NeoPixels (WS2811, WS2812 & SK6812) ea
 paragraph=Supports AVR and Esp8266 today.  For Esp8266 it has three methods of sending data, DMA, UART, and Bit Bang. Includes seperate RgbColor, RgbwColor, HslColor, and HsbColor objects.  Support for RGBW pixels.  Includes an animator class that helps create asyncronous animations.
 category=Display
 url=https://github.com/Makuna/NeoPixelBus
-architectures=avr,esp8266
+architectures=*

--- a/src/NeoArmMethod.h
+++ b/src/NeoArmMethod.h
@@ -1,0 +1,624 @@
+/*-------------------------------------------------------------------------
+NeoPixel library helper functions for ARM MCUs.
+Teensy 3.0, 3.1, LC, Arduino Due
+
+Written by Michael C. Miller.
+Some work taken from the Adafruit NeoPixel library.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/NeoPixelBus)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/NeoPixelBus library.
+The contents of this file were taken from the Adafruit NeoPixel library
+and modified only to fit within individual calling functions.
+
+NeoPixelBus is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+NeoPixelBus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with NeoPixel.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+#pragma once
+
+#if defined(__arm__)
+
+template<typename T_SPEED> class NeoArmMethodBase
+{
+public:
+    NeoArmMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize) :
+        _pin(pin)
+    {
+        pinMode(pin, OUTPUT);
+
+        _sizePixels = pixelCount * elementSize;
+        _pixels = (uint8_t*)malloc(_sizePixels);
+        memset(_pixels, 0, _sizePixels);
+    }
+
+    ~NeoArmMethodBase()
+    {
+        pinMode(_pin, INPUT);
+
+        free(_pixels);
+    }
+
+    bool IsReadyToUpdate() const
+    {
+        uint32_t delta = micros() - _endTime;
+
+        return (delta >= 50L);
+    }
+
+    void Initialize()
+    {
+        digitalWrite(_pin, LOW);
+
+        _endTime = micros();
+    }
+
+    void Update()
+    {
+        // Data latch = 50+ microsecond pause in the output stream.  Rather than
+        // put a delay at the end of the function, the ending time is noted and
+        // the function will simply hold off (if needed) on issuing the
+        // subsequent round of data until the latch time has elapsed.  This
+        // allows the mainline code to start generating the next frame of data
+        // rather than stalling for the latch.
+        while (!IsReadyToUpdate())
+        {
+            yield(); // allows for system yield if needed
+        }
+
+        noInterrupts(); // Need 100% focus on instruction timing
+
+        T_SPEED::send_pixels(_pixels, _sizePixels, _pin);
+
+        interrupts();
+
+        // save EOD time for latch on next call
+        _endTime = micros();
+    }
+
+    uint8_t* getPixels() const
+    {
+        return _pixels;
+    };
+
+    size_t getPixelsSize() const
+    {
+        return _sizePixels;
+    };
+
+private:
+    uint32_t _endTime;       // Latch timing reference
+    size_t    _sizePixels;   // Size of '_pixels' buffer below
+    uint8_t* _pixels;        // Holds LED color values
+    uint8_t _pin;            // output pin number
+};
+
+
+#if defined(__MK20DX128__) || defined(__MK20DX256__) // Teensy 3.0 & 3.1
+
+class NeoArmMk20dxSpeedProps800Kbps
+{
+public:
+    static const uint32_t CyclesT0h = (F_CPU / 4000000);
+    static const uint32_t CyclesT1h = (F_CPU / 1250000);
+    static const uint32_t Cycles = (F_CPU / 800000);
+};
+
+class NeoArmMk20dxSpeedProps400Kbps
+{
+public:
+    static const uint32_t CyclesT0h = (F_CPU / 2000000);
+    static const uint32_t CyclesT1h = (F_CPU / 833333);
+    static const uint32_t Cycles = (F_CPU / 400000);
+};
+
+template<typename T_SPEEDPROPS> class NeoArmMk20dxSpeedBase
+{
+public:
+    static void send_pixels(uint8_t* pixels, size_t sizePixels, uint8_t pin)
+    {
+        uint8_t* p = pixels;
+        uint8_t* end = p + sizePixels;
+        uint8_t pix;
+        uint8_t mask;
+
+        volatile uint8_t* set = portSetRegister(pin);
+        volatile uint8_t* clr = portClearRegister(pin);
+
+        uint32_t cyc;
+
+        ARM_DEMCR |= ARM_DEMCR_TRCENA;
+        ARM_DWT_CTRL |= ARM_DWT_CTRL_CYCCNTENA;
+
+        cyc = ARM_DWT_CYCCNT + T_SPEEDPROPS::Cycles;
+        while (p < end)
+        {
+            pix = *p++;
+            for (mask = 0x80; mask; mask >>= 1)
+            {
+                while (ARM_DWT_CYCCNT - cyc < T_SPEEDPROPS::Cycles);
+
+                cyc = ARM_DWT_CYCCNT;
+                *set = 1;
+                if (pix & mask)
+                {
+                    while (ARM_DWT_CYCCNT - cyc < T_SPEEDPROPS::CyclesT1h);
+                }
+                else
+                {
+                    while (ARM_DWT_CYCCNT - cyc < T_SPEEDPROPS::CyclesT0h);
+                }
+                *clr = 1;
+            }
+        }
+    }
+};
+
+typedef NeoArmMethodBase<NeoArmMk20dxSpeedBase<NeoArmMk20dxSpeedProps800Kbps>> NeoArm800KbpsMethod;
+typedef NeoArmMethodBase<NeoArmMk20dxSpeedBase<NeoArmMk20dxSpeedProps400Kbps>> NeoArm400KbpsMethod;
+
+#elif defined(__MKL26Z64__) // Teensy-LC
+
+#if F_CPU == 48000000
+
+
+
+class NeoArmMk26z64Speed800Kbps
+{
+public:
+    static void send_pixels(uint8_t* pixels, size_t sizePixels, uint8_t pin)
+    {
+        uint8_t* p = pixels;
+        uint8_t pix;
+        uint8_t count;
+        uint8_t dly;
+        uint8_t bitmask = digitalPinToBitMask(pin);
+        volatile uint8_t* reg = portSetRegister(pin);
+        uint32_t num = sizePixels;
+
+        asm volatile(
+            "L%=_begin:"				"\n\t"
+            "ldrb	%[pix], [%[p], #0]"		"\n\t"
+            "lsl	%[pix], #24"			"\n\t"
+            "movs	%[count], #7"			"\n\t"
+            "L%=_loop:"				"\n\t"
+            "lsl	%[pix], #1"			"\n\t"
+            "bcs	L%=_loop_one"			"\n\t"
+            "L%=_loop_zero:"
+            "strb	%[bitmask], [%[reg], #0]"	"\n\t"
+            "movs	%[dly], #4"			"\n\t"
+            "L%=_loop_delay_T0H:"			"\n\t"
+            "sub	%[dly], #1"			"\n\t"
+            "bne	L%=_loop_delay_T0H"		"\n\t"
+            "strb	%[bitmask], [%[reg], #4]"	"\n\t"
+            "movs	%[dly], #13"			"\n\t"
+            "L%=_loop_delay_T0L:"			"\n\t"
+            "sub	%[dly], #1"			"\n\t"
+            "bne	L%=_loop_delay_T0L"		"\n\t"
+            "b	L%=_next"			"\n\t"
+            "L%=_loop_one:"
+            "strb	%[bitmask], [%[reg], #0]"	"\n\t"
+            "movs	%[dly], #13"			"\n\t"
+            "L%=_loop_delay_T1H:"			"\n\t"
+            "sub	%[dly], #1"			"\n\t"
+            "bne	L%=_loop_delay_T1H"		"\n\t"
+            "strb	%[bitmask], [%[reg], #4]"	"\n\t"
+            "movs	%[dly], #4"			"\n\t"
+            "L%=_loop_delay_T1L:"			"\n\t"
+            "sub	%[dly], #1"			"\n\t"
+            "bne	L%=_loop_delay_T1L"		"\n\t"
+            "nop"					"\n\t"
+            "L%=_next:"				"\n\t"
+            "sub	%[count], #1"			"\n\t"
+            "bne	L%=_loop"			"\n\t"
+            "lsl	%[pix], #1"			"\n\t"
+            "bcs	L%=_last_one"			"\n\t"
+            "L%=_last_zero:"
+            "strb	%[bitmask], [%[reg], #0]"	"\n\t"
+            "movs	%[dly], #4"			"\n\t"
+            "L%=_last_delay_T0H:"			"\n\t"
+            "sub	%[dly], #1"			"\n\t"
+            "bne	L%=_last_delay_T0H"		"\n\t"
+            "strb	%[bitmask], [%[reg], #4]"	"\n\t"
+            "movs	%[dly], #10"			"\n\t"
+            "L%=_last_delay_T0L:"			"\n\t"
+            "sub	%[dly], #1"			"\n\t"
+            "bne	L%=_last_delay_T0L"		"\n\t"
+            "b	L%=_repeat"			"\n\t"
+            "L%=_last_one:"
+            "strb	%[bitmask], [%[reg], #0]"	"\n\t"
+            "movs	%[dly], #13"			"\n\t"
+            "L%=_last_delay_T1H:"			"\n\t"
+            "sub	%[dly], #1"			"\n\t"
+            "bne	L%=_last_delay_T1H"		"\n\t"
+            "strb	%[bitmask], [%[reg], #4]"	"\n\t"
+            "movs	%[dly], #1"			"\n\t"
+            "L%=_last_delay_T1L:"			"\n\t"
+            "sub	%[dly], #1"			"\n\t"
+            "bne	L%=_last_delay_T1L"		"\n\t"
+            "nop"					"\n\t"
+            "L%=_repeat:"				"\n\t"
+            "add	%[p], #1"			"\n\t"
+            "sub	%[num], #1"			"\n\t"
+            "bne	L%=_begin"			"\n\t"
+            "L%=_done:"				"\n\t"
+            : [p] "+r" (p),
+            [pix] "=&r" (pix),
+            [count] "=&r" (count),
+            [dly] "=&r" (dly),
+            [num] "+r" (num)
+            : [bitmask] "r" (bitmask),
+            [reg] "r" (reg)
+            );
+    }
+};
+
+typedef NeoArmMethodBase<NeoArmMk26z64Speed800Kbps> NeoArm800KbpsMethod;
+
+#else
+#error "Teensy-LC: Sorry, only 48 MHz is supported, please set Tools > CPU Speed to 48 MHz"
+#endif // F_CPU == 48000000
+
+#elif defined(__SAMD21G18A__) // Arduino Zero
+
+
+class NeoArmSamd21g18aSpeedProps800Kbps
+{
+public:
+    static void BitPreWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop;");
+    }
+    static void BitT1hWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop;");
+    }
+    static void BitT0lWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop;");
+    }
+    static void BitPostWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop; nop;");
+    }
+};
+
+class NeoArmSamd21g18aSpeedProps400Kbps
+{
+public:
+    static void BitPreWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;");
+    }
+    static void BitT1hWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop;");
+    }
+    static void BitT0lWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop;");
+    }
+    static void BitPostWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop;");
+    }
+};
+
+template<typename T_SPEEDPROPS> class NeoArmSamd21g18aSpeedBase
+{
+public:
+    static void send_pixels(uint8_t* pixels, size_t sizePixels, uint8_t pin)
+    {
+        // Tried this with a timer/counter, couldn't quite get adequate
+        // resolution.  So yay, you get a load of goofball NOPs...
+        uint8_t* ptr = pixels;
+        uint8_t* end = ptr + sizePixels;;
+        uint8_t p = *ptr++;
+        uint8_t bitMask = 0x80;
+        uint8_t portNum = g_APinDescription[pin].ulPort;
+        uint32_t pinMask = 1ul << g_APinDescription[pin].ulPin;
+
+        volatile uint32_t* set = &(PORT->Group[portNum].OUTSET.reg);
+        volatile uint32_t* clr = &(PORT->Group[portNum].OUTCLR.reg);
+
+        for (;;)
+        {
+            *set = pinMask;
+            T_SPEEDPROPS::BitPreWait();
+
+            if (p & bitMask)
+            {
+                T_SPEEDPROPS::BitT1hWait();
+                *clr = pinMask;
+            }
+            else
+            {
+                *clr = pinMask;
+                T_SPEEDPROPS::BitT0lWait();
+            }
+            if (bitMask >>= 1)
+            {
+                T_SPEEDPROPS::BitPostWait();
+            }
+            else
+            {
+                if (ptr >= end)
+                {
+                    break;
+                }
+                p = *ptr++;
+                bitMask = 0x80;
+            }
+        }
+    }
+};
+
+typedef NeoArmMethodBase<NeoArmSamd21g18aSpeedBase<NeoArmSamd21g18aSpeedProps800Kbps>> NeoArm800KbpsMethod;
+typedef NeoArmMethodBase<NeoArmSamd21g18aSpeedBase<NeoArmSamd21g18aSpeedProps400Kbps>> NeoArm400KbpsMethod;
+
+#elif defined (ARDUINO_STM32_FEATHER) // FEATHER WICED (120MHz)
+
+
+
+class NeoArmStm32SpeedProps800Kbps
+{
+    static void BitT1hWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop;");
+    }
+    static void BitT1lWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop;");
+    }
+    static void BitT0hWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop;");
+    }
+    static void BitT0lWait()
+    {
+        asm("nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop; nop; nop; nop; nop;"
+            "nop; nop; nop; nop;");
+    }
+
+
+};
+/* TODO - not found in Adafruit library
+class NeoArmStm32SpeedProps400Kbps
+{
+static void BitT1hWait()
+{
+}
+static void BitT1lWait()
+{
+}
+static void BitT0hWait()
+{
+}
+static void BitT0lWait()
+{
+}
+};
+*/
+
+template<typename T_SPEEDPROPS> class NeoArmStm32SpeedBase
+{
+    static void send_pixels(uint8_t* pixels, size_t sizePixels, uint8_t pin)
+    {
+        // Tried this with a timer/counter, couldn't quite get adequate
+        // resolution.  So yay, you get a load of goofball NOPs...
+
+        uint8_t* ptr = pixels;
+        uint8_t* end = ptr + sizePixels;
+        uint8_t p = *ptr++;
+        uint8_t bitMask = 0x80;
+        uint32_t  pinMask = BIT(PIN_MAP[pin].gpio_bit);
+
+        volatile uint16_t* set = &(PIN_MAP[pin].gpio_device->regs->BSRRL);
+        volatile uint16_t* clr = &(PIN_MAP[pin].gpio_device->regs->BSRRH);
+
+        for (;;)
+        {
+            if (p & bitMask)
+            {
+                // ONE
+                // High 800ns
+                *set = pinMask;
+                T_SPEEDPROPS::BitT1hWait();
+                // Low 450ns
+                *clr = pinMask;
+                T_SPEEDPROPS::BitT1lWait();
+            }
+            else
+            {
+                // ZERO
+                // High 400ns
+                *set = pinMask;
+                T_SPEEDPROPS::BitT0hWait();
+                // Low 850ns
+                *clr = pinMask;
+                T_SPEEDPROPS::BitT0lWait();
+            }
+            if (bitMask >>= 1)
+            {
+                // Move on to the next pixel
+                asm("nop;");
+            }
+            else
+            {
+                if (ptr >= end)
+                {
+                    break;
+                }
+
+                p = *ptr++;
+                bitMask = 0x80;
+            }
+        }
+    }
+};
+
+typedef NeoArmMethodBase<NeoArmStm32SpeedBase<NeoArmStm32SpeedProps800Kbps>> NeoArm800KbpsMethod;
+
+#else // Other ARM architecture -- Presumed Arduino Due
+
+
+#define ARM_OTHER_SCALE  VARIANT_MCK / 2UL / 1000000UL
+#define ARM_OTHER_INST   (2UL * F_CPU / VARIANT_MCK)
+
+class NeoArmOtherSpeedProps800Kbps
+{
+public:
+    static const uint32_t CyclesT0h = ((uint32_t)(0.40 * ARM_OTHER_SCALE + 0.5) - (5 * ARM_OTHER_INST));
+    static const uint32_t CyclesT1h = ((uint32_t)(0.80 * ARM_OTHER_SCALE + 0.5) - (5 * ARM_OTHER_INST));
+    static const uint32_t Cycles = ((uint32_t)(1.25 * ARM_OTHER_SCALE + 0.5) - (5 * ARM_OTHER_INST));
+};
+
+class NeoArmOtherSpeedProps400Kbps
+{
+public:
+    static const uint32_t CyclesT0h = ((uint32_t)(0.50 * ARM_OTHER_SCALE + 0.5) - (5 * ARM_OTHER_INST));
+    static const uint32_t CyclesT1h = ((uint32_t)(1.20 * ARM_OTHER_SCALE + 0.5) - (5 * ARM_OTHER_INST));
+    static const uint32_t Cycles = ((uint32_t)(2.50 * ARM_OTHER_SCALE + 0.5) - (5 * ARM_OTHER_INST));
+};
+
+template<typename T_SPEEDPROPS> class NeoArmOtherSpeedBase
+{
+public:
+    static void send_pixels(uint8_t* pixels, size_t sizePixels, uint8_t pin)
+    {
+        uint32_t pinMask;
+        uint32_t t;
+        Pio* port;
+        volatile WoReg* portSet;
+        volatile WoReg* portClear;
+        volatile WoReg* timeValue;
+        volatile WoReg* timeReset;
+        uint8_t* p;
+        uint8_t* end;
+        uint8_t pix;
+        uint8_t mask;
+
+        pmc_set_writeprotect(false);
+        pmc_enable_periph_clk((uint32_t)TC3_IRQn);
+
+        TC_Configure(TC1, 0,
+            TC_CMR_WAVE | TC_CMR_WAVSEL_UP | TC_CMR_TCCLKS_TIMER_CLOCK1);
+        TC_Start(TC1, 0);
+
+        pinMask = g_APinDescription[pin].ulPin; // Don't 'optimize' these into
+        port = g_APinDescription[pin].pPort; // declarations above.  Want to
+        portSet = &(port->PIO_SODR);            // burn a few cycles after
+        portClear = &(port->PIO_CODR);            // starting timer to minimize
+        timeValue = &(TC1->TC_CHANNEL[0].TC_CV);  // the initial 'while'.
+        timeReset = &(TC1->TC_CHANNEL[0].TC_CCR);
+        p = pixels;
+        end = p + sizePixels;
+        pix = *p++;
+        mask = 0x80;
+
+        for (;;)
+        {
+            if (pix & mask)
+            {
+                t = T_SPEEDPROPS::CyclesT1h;
+            }
+            else
+            {
+                t = T_SPEEDPROPS::CyclesT0h;
+            }
+
+            // wait for the end of the previous cycle
+            while (*timeValue < T_SPEEDPROPS::Cycles);
+
+            *portSet = pinMask;
+            *timeReset = TC_CCR_CLKEN | TC_CCR_SWTRG;
+
+            while (*timeValue < t);
+
+            *portClear = pinMask;
+            if (!(mask >>= 1))
+            {
+                // This 'inside-out' loop logic utilizes
+                if (p >= end)
+                {
+                    break; // idle time to minimize inter-byte delays.
+                }
+                pix = *p++;
+                mask = 0x80;
+            }
+        }
+
+        // not really needed as the wait for latch does this and
+        // while (*timeValue < T_SPEEDPROPS::Cycles); // Wait for last bit
+
+        TC_Stop(TC1, 0);
+    }
+};
+
+typedef NeoArmMethodBase<NeoArmOtherSpeedBase<NeoArmOtherSpeedProps800Kbps>> NeoArm800KbpsMethod;
+typedef NeoArmMethodBase<NeoArmOtherSpeedBase<NeoArmOtherSpeedProps400Kbps>> NeoArm400KbpsMethod;
+
+#endif
+
+
+// Arm doesn't have alternatives methods yet, so only one to make the default
+typedef NeoArm800KbpsMethod Neo800KbpsMethod;
+#ifdef NeoArm400KbpsMethod // this is needed due to missing 400Kbps for some platforms
+typedef NeoArm400KbpsMethod Neo400KbpsMethod;
+#endif
+
+#endif // defined(__arm__)
+

--- a/src/NeoAvrMethod.h
+++ b/src/NeoAvrMethod.h
@@ -138,7 +138,9 @@ public:
         // rather than stalling for the latch.
         while (!IsReadyToUpdate())
         {
+#if !defined(ARDUINO_TEEONARDU_LEO) && !defined(ARDUINO_TEEONARDU_FLORA)
             yield(); // allows for system yield if needed
+#endif
         }
 
         noInterrupts(); // Need 100% focus on instruction timing
@@ -173,6 +175,10 @@ private:
 
 typedef NeoAvrMethodBase<NeoAvrSpeed800Kbps> NeoAvr800KbpsMethod;
 typedef NeoAvrMethodBase<NeoAvrSpeed400Kbps> NeoAvr400KbpsMethod;
+
+// AVR doesn't have alternatives yet, so there is just the default
+typedef NeoAvr800KbpsMethod Neo800KbpsMethod;
+typedef NeoAvr400KbpsMethod Neo400KbpsMethod;
 
 #endif
 

--- a/src/NeoEsp8266DmaMethod.h
+++ b/src/NeoEsp8266DmaMethod.h
@@ -330,4 +330,8 @@ private:
 typedef NeoEsp8266DmaMethodBase<NeoEsp8266DmaSpeed800Kbps> NeoEsp8266Dma800KbpsMethod;
 typedef NeoEsp8266DmaMethodBase<NeoEsp8266DmaSpeed400Kbps> NeoEsp8266Dma400KbpsMethod;
 
+// Dma  method is the default method for Esp8266
+typedef NeoEsp8266Dma800KbpsMethod Neo800KbpsMethod;
+typedef NeoEsp8266Dma400KbpsMethod Neo400KbpsMethod;
+
 #endif

--- a/src/NeoPixelAnimator.cpp
+++ b/src/NeoPixelAnimator.cpp
@@ -75,7 +75,7 @@ void NeoPixelAnimator::StartAnimation(uint16_t n,
         uint16_t duration, 
         AnimUpdateCallback animUpdate)
 {
-    if (n >= _countAnimations)
+    if (n >= _countAnimations || animUpdate == NULL)
     {
         return;
     }
@@ -140,8 +140,7 @@ void NeoPixelAnimator::UpdateAnimations()
                     param.state = (pAnim->_remaining == pAnim->_duration) ? AnimationState_Started : AnimationState_Progress;
                     param.progress = (float)(pAnim->_duration - pAnim->_remaining) / (float)pAnim->_duration;
 
-                    if (fnUpdate)
-                        fnUpdate(param);
+                    fnUpdate(param);
 
                     pAnim->_remaining -= delta;
 
@@ -155,8 +154,7 @@ void NeoPixelAnimator::UpdateAnimations()
                     _activeAnimations--; 
                     pAnim->StopAnimation();
 
-                    if (fnUpdate)
-                        fnUpdate(param);
+                    fnUpdate(param);
                     
                     countAnimations--;
                 }

--- a/src/NeoPixelAnimator.h
+++ b/src/NeoPixelAnimator.h
@@ -48,6 +48,8 @@ typedef void(*AnimUpdateCallback)(const AnimationParam& param);
 
 #else
 
+#undef max
+#undef min
 #include <functional>
 typedef std::function<void(const AnimationParam& param)> AnimUpdateCallback;
 

--- a/src/NeoPixelAvr.c
+++ b/src/NeoPixelAvr.c
@@ -33,7 +33,8 @@ License along with NeoPixel.  If not, see
 <http://www.gnu.org/licenses/>.
 -------------------------------------------------------------------------*/
 
-#ifdef ARDUINO_ARCH_AVR
+// must also check for arm due to Teensy incorrectly having ARDUINO_ARCH_AVR set
+#if defined(ARDUINO_ARCH_AVR) && !defined(__arm__)
 
 #include <Arduino.h>
 
@@ -53,6 +54,7 @@ License along with NeoPixel.  If not, see
 
 #if (F_CPU >= 7400000UL) && (F_CPU <= 9500000UL)  // 8Mhz CPU
 
+#ifdef PORTD // PORTD isn't present on ATtiny85, etc.
 void send_pixels_8mhz_800_PortD(uint8_t* pixels, size_t sizePixels, uint8_t pinMask)
 {
     volatile size_t i = sizePixels; // Loop counter
@@ -176,6 +178,7 @@ void send_pixels_8mhz_800_PortD(uint8_t* pixels, size_t sizePixels, uint8_t pinM
         [hi]     "r" (hi),
         [lo]     "r" (lo) );
 }
+#endif
 
 void send_pixels_8mhz_800_PortB(uint8_t* pixels, size_t sizePixels, uint8_t pinMask)
 {
@@ -327,6 +330,7 @@ void send_pixels_8mhz_400(uint8_t* pixels, size_t sizePixels, volatile uint8_t* 
 
 #elif (F_CPU >= 11100000UL) && (F_CPU <= 14300000UL)  // 12Mhz CPU
 
+#ifdef PORTD // PORTD isn't present on ATtiny85, etc.
 void send_pixels_12mhz_800_PortD(uint8_t* pixels, size_t sizePixels, uint8_t pinMask)
 {
     volatile size_t i = sizePixels; // Loop counter
@@ -398,10 +402,11 @@ void send_pixels_12mhz_800_PortD(uint8_t* pixels, size_t sizePixels, uint8_t pin
         [hi]     "r" (hi),
         [lo]     "r" (lo));
 }
+#endif
 
 void send_pixels_12mhz_800_PortB(uint8_t* pixels, size_t sizePixels, uint8_t pinMask)
 {
-    volatile size_t i = sizePixels; // Loop counter
+    volatile uint16_t i = (uint16_t)sizePixels; // Loop counter
     volatile uint8_t* ptr = pixels; // Pointer to next byte
     volatile uint8_t b = *ptr++;    // Current byte value
     volatile uint8_t hi;            // PORT w/output bit set high
@@ -463,7 +468,7 @@ void send_pixels_12mhz_800_PortB(uint8_t* pixels, size_t sizePixels, uint8_t pin
 
 void send_pixels_12mhz_400(uint8_t* pixels, size_t sizePixels, volatile uint8_t* port, uint8_t pinMask)
 {
-    volatile size_t i = sizePixels; // Loop counter
+    volatile uint16_t i = (uint16_t)sizePixels; // Loop counter
     volatile uint8_t* ptr = pixels; // Pointer to next byte
     volatile uint8_t b = *ptr++;    // Current byte value
     volatile uint8_t hi;            // PORT w/output bit set high
@@ -519,7 +524,7 @@ void send_pixels_12mhz_400(uint8_t* pixels, size_t sizePixels, volatile uint8_t*
 
 void send_pixels_16mhz_800(uint8_t* pixels, size_t sizePixels, volatile uint8_t* port, uint8_t pinMask)
 {
-    volatile size_t i = sizePixels; // Loop counter
+    volatile uint16_t i = (uint16_t)sizePixels; // Loop counter
     volatile uint8_t* ptr = pixels; // Pointer to next byte
     volatile uint8_t b = *ptr++;    // Current byte value
     volatile uint8_t hi;            // PORT w/output bit set high
@@ -531,7 +536,8 @@ void send_pixels_16mhz_800(uint8_t* pixels, size_t sizePixels, volatile uint8_t*
     // 20 inst. clocks per bit: HHHHHxxxxxxxxLLLLLLL
     // ST instructions:         ^   ^        ^       (T=0,5,13)
 
-    volatile uint8_t next, bit;
+    volatile uint8_t next;
+    volatile uint8_t bit;
 
     hi = *port | pinMask;
     lo = *port & ~pinMask;

--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -33,11 +33,13 @@ License along with NeoPixel.  If not, see
 #include "RgbwColor.h"
 #include "NeoColorFeatures.h"
 
-#ifdef ARDUINO_ARCH_ESP8266
+#if defined(ARDUINO_ARCH_ESP8266)
 #include "NeoEsp8266DmaMethod.h"
 #include "NeoEsp8266UartMethod.h"
 #include "NeoEsp8266BitBangMethod.h"
-#elif ARDUINO_ARCH_AVR
+#elif defined(__arm__) // must be before ARDUINO_ARCH_AVR due to Teensy incorrectly having it set
+#include "NeoArmMethod.h"
+#elif defined(ARDUINO_ARCH_AVR)
 #include "NeoAvrMethod.h"
 #else
 #error "Platform Currently Not Supported, please add an Issue at Github/Makuna/NeoPixelBus"
@@ -83,7 +85,7 @@ public:
 
     inline bool CanShow() const
     { 
-        _method.IsReadyToUpdate();
+        return _method.IsReadyToUpdate();
     };
 
     bool IsDirty() const

--- a/src/RgbwColor.cpp
+++ b/src/RgbwColor.cpp
@@ -29,25 +29,6 @@ License along with NeoPixel.  If not, see
 #include "HsbColor.h"
 #include "RgbwColor.h"
 
-static float _CalcColor(float p, float q, float t)
-{
-    if (t < 0.0f)
-        t += 1.0f;
-    if (t > 1.0f)
-        t -= 1.0f;
-
-    if (t < 1.0f / 6.0f)
-        return p + (q - p) * 6.0f * t;
-
-    if (t < 0.5f)
-        return q;
-
-    if (t < 2.0f / 3.0f)
-        return p + ((q - p) * (2.0f / 3.0f - t) * 6.0f);
-
-    return p;
-}
-
 RgbwColor::RgbwColor(HslColor color)
 {
     RgbColor rgbColor(color);


### PR DESCRIPTION
Made a default method to reduce complexity with platforms that only have
two speed methods (esp8266 is the only one that has different methods)