### PR TITLE
Refactored To Remove CSS3 define

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -68,6 +68,8 @@ NeoBufferProgmemMethod	KEYWORD1
 NeoBuffer	KEYWORD1
 NeoVerticalSpriteSheet	KEYWORD1
 NeoBitmapFile	KEYWORD1
+HtmlShortColorNames	KEYWORD1
+HtmlColorNames	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/Makuna/NeoPixelBus"
   },
-  "version": "2.1.3",
+  "version": "2.1.4",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=NeoPixelBus by Makuna
-version=2.1.3
+version=2.1.4
 author=Michael C. Miller (makuna@live.com)
 maintainer=Michael C. Miller (makuna@live.com)
 sentence=A library that makes controlling NeoPixels (WS2811, WS2812 & SK6812) easy.

--- a/src/internal/HtmlColor.h
+++ b/src/internal/HtmlColor.h
@@ -28,9 +28,45 @@ License along with NeoPixel.  If not, see
 #include <Arduino.h>
 #include "RgbColor.h"
 
-// Due to Arduino's lack of Project settings for symbols, library code (c,cpp)
-// files can't react to defines in sketch, so this must be defined here
-// #define USE_CSS3_COLORS 1
+#define MAX_HTML_COLOR_NAME_LEN 21
+
+#ifndef pgm_read_ptr
+// ESP8266 doesn't define this macro
+#define pgm_read_ptr(addr) (*reinterpret_cast<const void* const *>(addr))
+#endif
+
+#ifndef countof
+#define countof(array) (sizeof(array)/sizeof(array[0]))
+#endif
+
+// ------------------------------------------------------------------------
+// HtmlColorPair represents an association between a name and a HTML color code
+// ------------------------------------------------------------------------
+struct HtmlColorPair
+{
+    PGM_P Name;
+    uint32_t Color;
+};
+
+// ------------------------------------------------------------------------
+// HtmlShortColorNames is a template class used for Parse and ToString
+// ------------------------------------------------------------------------
+class HtmlShortColorNames
+{
+public:
+    static const HtmlColorPair* Pair(uint8_t index);
+    static uint8_t Count();
+};
+
+// ------------------------------------------------------------------------
+// HtmlColorNames is a template class used for Parse and ToString
+// ------------------------------------------------------------------------
+class HtmlColorNames
+{
+public:
+    static const HtmlColorPair* Pair(uint8_t index);
+    static uint8_t Count();
+};
 
 // ------------------------------------------------------------------------
 // HtmlColor represents a color object that is represented by a single uint32
@@ -80,7 +116,7 @@ struct HtmlColor
 
     // ------------------------------------------------------------------------
     // Parse a HTML4/CSS3 color name
-    //
+    // T_HTMLCOLORNAMES - template class that defines the collection of names
     // name - the color name
     // nameSize - the max size of name to check
     //
@@ -89,9 +125,6 @@ struct HtmlColor
     // It will stop parsing name when a null terminator is reached, 
     // nameSize is reached, no match is found in the name/color pair table, or
     // a non-alphanumeric is read like seperators or whitespace.
-    //
-    // It accepts all standard HTML4 names and, if USE_CSS3_COLORS macro is
-    // defined, the extended color names defined in CSS3 standard also.
     //
     // It also accepts 3 or 6 digit hexadecimal notation (#rgb or #rrggbb),
     // but it doesn't accept RGB, RGBA nor HSL values.
@@ -102,22 +135,135 @@ struct HtmlColor
     // parsing will stop at the first non-alpha numeric
     //
     // Name MUST NOT be a PROGMEM pointer
+    //
+    // examples:
+    //  Parse<HtmlShortColorNames>(buff, buffSize);
+    //  Parse<HtmlColorNames>(buff, buffSize);
     // ------------------------------------------------------------------------
-    size_t Parse(const char* name, size_t nameSize);
 
-    size_t Parse(const char* name)
-    { 
-        return Parse(name, strlen(name) + 1); 
+    template <typename T_HTMLCOLORNAMES> size_t Parse(const char* name, size_t nameSize)
+    {
+        if (nameSize > 0)
+        {
+            if (name[0] == '#')
+            {
+                // Parse an hexadecimal notation "#rrbbgg" or "#rgb"
+                //
+                uint8_t temp[6]; // stores preconverted chars to hex values
+                uint8_t tempSize = 0;
+
+                for (uint8_t indexChar = 1; indexChar < nameSize && indexChar < 8; ++indexChar)
+                {
+                    char c = name[indexChar];
+                    if (c >= '0' && c <= '9')
+                    {
+                        c -= '0';
+                    }
+                    else
+                    {
+                        // Convert a letter to lower case (only for ASCII letters)
+                        // It's faster & smaller than tolower()
+                        c |= 32;
+                        if (c >= 'a' && c <= 'f')
+                        {
+                            c = c - 'a' + 10;
+                        }
+                        else
+                        {
+                            // we found an non hexidecimal char
+                            // which could be null, deliminator, or other spacing
+                            break;
+                        }
+                    }
+
+                    temp[tempSize] = c;
+                    tempSize++;
+                }
+
+                if (tempSize != 3 && tempSize != 6)
+                {
+                    // invalid count of numerical chars
+                    return 0;
+                }
+                else
+                {
+                    uint32_t color = 0;
+                    for (uint8_t indexChar = 0; indexChar < tempSize; ++indexChar)
+                    {
+                        color = color * 16 + temp[indexChar];
+                        if (tempSize == 3)
+                        {
+                            // 3 digit hexadecimal notation can be supported easily
+                            // duplicating digits.
+                            color = color * 16 + temp[indexChar];
+                        }
+                    }
+
+                    Color = color;
+                    return tempSize;
+                }
+            }
+            else
+            {
+                // parse a standard name for the color
+                //
+
+                // the normal list is small enough a binary search isn't interesting,
+                for (uint8_t indexName = 0; indexName < T_HTMLCOLORNAMES::Count(); ++indexName)
+                {
+                    const HtmlColorPair* colorPair = T_HTMLCOLORNAMES::Pair(indexName);
+                    PGM_P searchName = (PGM_P)pgm_read_ptr(&colorPair->Name);
+                    size_t str1Size = nameSize;
+                    const char* str1 = name;
+                    const char* str2P = searchName;
+
+                    uint16_t result;
+
+                    while (str1Size > 0)
+                    {
+                        char ch1 = tolower(*str1++);
+                        char ch2 = tolower(pgm_read_byte(str2P++));
+                        result = ch1 - ch2;
+                        if (result != 0 || ch2 == '\0')
+                        {
+                            if (ch2 == '\0' && !isalnum(ch1))
+                            {
+                                // the string continues but is not part of a
+                                // valid color name, 
+                                // ends in white space, deliminator, etc
+                                result = 0;
+                            }
+                            break;
+                        }
+                        result = -1; // have not reached the end of searchName;
+                        str1Size--;
+                    }
+
+                    if (result == 0)
+                    {
+                        Color = pgm_read_dword(&colorPair->Color);
+                        return nameSize - str1Size;
+                    }
+                }
+            }
+        }
+
+        return 0;
     }
 
-    size_t Parse(String const &name)
+    template <typename T_HTMLCOLORNAMES> size_t Parse(const char* name)
     { 
-        return Parse(name.c_str(), name.length() + 1); 
+        return Parse<T_HTMLCOLORNAMES>(name, MAX_HTML_COLOR_NAME_LEN + 1);
+    }
+
+    template <typename T_HTMLCOLORNAMES> size_t Parse(String const &name)
+    { 
+        return Parse<T_HTMLCOLORNAMES>(name.c_str(), name.length() + 1);
     }
 
     // ------------------------------------------------------------------------
     // Converts this color code to its HTML4/CSS3 name
-    //
+    // T_HTMLCOLORNAMES - template class that defines the collection of names
     // buf - buffer to write the string
     // bufSize - actual size of buf array
     //
@@ -125,8 +271,29 @@ struct HtmlColor
     //
     // If there is not enough space in the buffer, it will write as many
     // characters as allowed and will always finish the buffer with a NUL char
+    //
+    // examples:
+    //  ToString<HtmlShortColorNames>(buf, bufSize);
+    //  ToString<htmlColorNames>(buf, bufSize);
     // ------------------------------------------------------------------------
-    size_t ToString(char *buf, size_t bufSize) const;
+
+    template <typename T_HTMLCOLORNAMES> size_t ToString(char* buf, size_t bufSize) const
+    {
+        // search for a color value/name pairs first
+        for (uint8_t indexName = 0; indexName < T_HTMLCOLORNAMES::Count(); ++indexName)
+        {
+            const HtmlColorPair* colorPair = T_HTMLCOLORNAMES::Pair(indexName);
+            if (pgm_read_dword(&colorPair->Color) == Color)
+            {
+                PGM_P name = (PGM_P)pgm_read_ptr(&colorPair->Name);
+                strncpy_P(buf, name, bufSize);
+                return strlen_P(name);
+            }
+        }
+
+        // no color name pair match, convert using numerical format
+        return ToNumericalString(buf, bufSize);
+    }
 
     // ------------------------------------------------------------------------
     // Converts this color code to its HTML4/CSS3 numerical name
@@ -139,6 +306,7 @@ struct HtmlColor
     // If there is not enough space in the buffer, it will write as many
     // characters as allowed and will always finish the buffer with a NUL char
     // ------------------------------------------------------------------------
+
     size_t ToNumericalString(char* buf, size_t bufSize) const;
 
     // ------------------------------------------------------------------------
@@ -150,6 +318,7 @@ struct HtmlColor
     // x - unit value (0.0 - 1.0) that defines the blend progress in horizontal space
     // y - unit value (0.0 - 1.0) that defines the blend progress in vertical space
     // ------------------------------------------------------------------------
+
     static HtmlColor BilinearBlend(const HtmlColor& c00,
         const HtmlColor& c01,
         const HtmlColor& c10,

--- a/src/internal/HtmlColorNameStrings.cpp
+++ b/src/internal/HtmlColorNameStrings.cpp
@@ -1,0 +1,178 @@
+/*-------------------------------------------------------------------------
+HtmlColorNameStrings provides the implemenation of the color string names
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/NeoPixelBus)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/NeoPixelBus library.
+
+NeoPixelBus is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+NeoPixelBus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with NeoPixel.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+#include "HtmlColorNameStrings.h"
+
+/* HTML4 color names */
+const char c_HtmlNameAqua[] PROGMEM = "aqua";
+const char c_HtmlNameBlack[] PROGMEM = "black";
+const char c_HtmlNameBlue[] PROGMEM = "blue";
+const char c_HtmlNameFuchsia[] PROGMEM = "fuchsia";
+const char c_HtmlNameGray[] PROGMEM = "gray";
+const char c_HtmlNameGreen[] PROGMEM = "green";
+const char c_HtmlNameLime[] PROGMEM = "lime";
+const char c_HtmlNameMaroon[] PROGMEM = "maroon";
+const char c_HtmlNameNavy[] PROGMEM = "navy";
+const char c_HtmlNameOlive[] PROGMEM = "olive";
+const char c_HtmlNameOrange[] PROGMEM = "orange";
+const char c_HtmlNamePurple[] PROGMEM = "purple";
+const char c_HtmlNameRed[] PROGMEM = "red";
+const char c_HtmlNameSilver[] PROGMEM = "silver";
+const char c_HtmlNameTeal[] PROGMEM = "teal";
+const char c_HtmlNameWhite[] PROGMEM = "white";
+const char c_HtmlNameYellow[] PROGMEM = "yellow";
+
+/* Additional CSS3 color names */
+const char c_HtmlNameAliceBlue[] PROGMEM = "aliceblue";
+const char c_HtmlNameAntiqueWhite[] PROGMEM = "antiquewhite";
+const char c_HtmlNameAquamarine[] PROGMEM = "aquamarine";
+const char c_HtmlNameAzure[] PROGMEM = "azure";
+const char c_HtmlNameBeige[] PROGMEM = "beige";
+const char c_HtmlNameBisque[] PROGMEM = "bisque";
+const char c_HtmlNameBlanchedAlmond[] PROGMEM = "blanchedalmond";
+const char c_HtmlNameBlueViolet[] PROGMEM = "blueviolet";
+const char c_HtmlNameBrown[] PROGMEM = "brown";
+const char c_HtmlNameBurlyWood[] PROGMEM = "burlywood";
+const char c_HtmlNameCadetBlue[] PROGMEM = "cadetblue";
+const char c_HtmlNameChartreuse[] PROGMEM = "chartreuse";
+const char c_HtmlNameChocolate[] PROGMEM = "chocolate";
+const char c_HtmlNameCoral[] PROGMEM = "coral";
+const char c_HtmlNameCornflowerBlue[] PROGMEM = "cornflowerblue";
+const char c_HtmlNameCornsilk[] PROGMEM = "cornsilk";
+const char c_HtmlNameCrimson[] PROGMEM = "crimson";
+const char c_HtmlNameCyan[] PROGMEM = "cyan";
+const char c_HtmlNameDarkBlue[] PROGMEM = "darkblue";
+const char c_HtmlNameDarkCyan[] PROGMEM = "darkcyan";
+const char c_HtmlNameDarkGoldenrod[] PROGMEM = "darkgoldenrod";
+const char c_HtmlNameDarkGray[] PROGMEM = "darkgray";
+const char c_HtmlNameDarkGreen[] PROGMEM = "darkgreen";
+const char c_HtmlNameDarkGrey[] PROGMEM = "darkgrey";
+const char c_HtmlNameDarkKhaki[] PROGMEM = "darkkhaki";
+const char c_HtmlNameDarkMagenta[] PROGMEM = "darkmagenta";
+const char c_HtmlNameDarkOliveGreen[] PROGMEM = "darkolivegreen";
+const char c_HtmlNameDarkOrange[] PROGMEM = "darkorange";
+const char c_HtmlNameDarkOrchid[] PROGMEM = "darkorchid";
+const char c_HtmlNameDarkRed[] PROGMEM = "darkred";
+const char c_HtmlNameDarkSalmon[] PROGMEM = "darksalmon";
+const char c_HtmlNameDarkSeaGreen[] PROGMEM = "darkseagreen";
+const char c_HtmlNameDarkSlateBlue[] PROGMEM = "darkslateblue";
+const char c_HtmlNameDarkSlateGray[] PROGMEM = "darkslategray";
+const char c_HtmlNameDarkSlateGrey[] PROGMEM = "darkslategrey";
+const char c_HtmlNameDarkTurquoise[] PROGMEM = "darkturquoise";
+const char c_HtmlNameDarkViolet[] PROGMEM = "darkviolet";
+const char c_HtmlNameDeepPink[] PROGMEM = "deeppink";
+const char c_HtmlNameDeepSkyBlue[] PROGMEM = "deepskyblue";
+const char c_HtmlNameDimGray[] PROGMEM = "dimgray";
+const char c_HtmlNameDimGrey[] PROGMEM = "dimgrey";
+const char c_HtmlNameDodgerBlue[] PROGMEM = "dodgerblue";
+const char c_HtmlNameFirebrick[] PROGMEM = "firebrick";
+const char c_HtmlNameFloralWhite[] PROGMEM = "floralwhite";
+const char c_HtmlNameForestGreen[] PROGMEM = "forestgreen";
+const char c_HtmlNameGainsboro[] PROGMEM = "gainsboro";
+const char c_HtmlNameGhostWhite[] PROGMEM = "ghostwhite";
+const char c_HtmlNameGold[] PROGMEM = "gold";
+const char c_HtmlNameGoldenrod[] PROGMEM = "goldenrod";
+const char c_HtmlNameGreenYellow[] PROGMEM = "greenyellow";
+const char c_HtmlNameGrey[] PROGMEM = "grey";
+const char c_HtmlNameHoneydew[] PROGMEM = "honeydew";
+const char c_HtmlNameHotPink[] PROGMEM = "hotpink";
+const char c_HtmlNameIndianRed[] PROGMEM = "indianred";
+const char c_HtmlNameIndigo[] PROGMEM = "indigo";
+const char c_HtmlNameIvory[] PROGMEM = "ivory";
+const char c_HtmlNameKhaki[] PROGMEM = "khaki";
+const char c_HtmlNameLavender[] PROGMEM = "lavender";
+const char c_HtmlNameLavenderBlush[] PROGMEM = "lavenderblush";
+const char c_HtmlNameLawnGreen[] PROGMEM = "lawngreen";
+const char c_HtmlNameLemonChiffon[] PROGMEM = "lemonchiffon";
+const char c_HtmlNameLightBlue[] PROGMEM = "lightblue";
+const char c_HtmlNameLightCoral[] PROGMEM = "lightcoral";
+const char c_HtmlNameLightCyan[] PROGMEM = "lightcyan";
+const char c_HtmlNameLightGoldenrodYellow[] PROGMEM = "lightgoldenrodyellow";
+const char c_HtmlNameLightGray[] PROGMEM = "lightgray";
+const char c_HtmlNameLightGreen[] PROGMEM = "lightgreen";
+const char c_HtmlNameLightGrey[] PROGMEM = "lightgrey";
+const char c_HtmlNameLightPink[] PROGMEM = "lightpink";
+const char c_HtmlNameLightSalmon[] PROGMEM = "lightsalmon";
+const char c_HtmlNameLightSeaGreen[] PROGMEM = "lightseagreen";
+const char c_HtmlNameLightSkyBlue[] PROGMEM = "lightskyblue";
+const char c_HtmlNameLightSlateGray[] PROGMEM = "lightslategray";
+const char c_HtmlNameLightSlateGrey[] PROGMEM = "lightslategrey";
+const char c_HtmlNameLightSteelBlue[] PROGMEM = "lightsteelblue";
+const char c_HtmlNameLightYellow[] PROGMEM = "lightyellow";
+const char c_HtmlNameLimeGreen[] PROGMEM = "limegreen";
+const char c_HtmlNameLinen[] PROGMEM = "linen";
+const char c_HtmlNameMagenta[] PROGMEM = "magenta";
+const char c_HtmlNameMediumAquamarine[] PROGMEM = "mediumaquamarine";
+const char c_HtmlNameMediumBlue[] PROGMEM = "mediumblue";
+const char c_HtmlNameMediumOrchid[] PROGMEM = "mediumorchid";
+const char c_HtmlNameMediumPurple[] PROGMEM = "mediumpurple";
+const char c_HtmlNameMediumSeagreen[] PROGMEM = "mediumseagreen";
+const char c_HtmlNameMediumSlateBlue[] PROGMEM = "mediumslateblue";
+const char c_HtmlNameMediumSpringGreen[] PROGMEM = "mediumspringgreen";
+const char c_HtmlNameMediumTurquoise[] PROGMEM = "mediumturquoise";
+const char c_HtmlNameMediumVioletRed[] PROGMEM = "mediumvioletred";
+const char c_HtmlNameMidnightBlue[] PROGMEM = "midnightblue";
+const char c_HtmlNameMintCream[] PROGMEM = "mintcream";
+const char c_HtmlNameMistyRose[] PROGMEM = "mistyrose";
+const char c_HtmlNameMoccasin[] PROGMEM = "moccasin";
+const char c_HtmlNameNavajoWhite[] PROGMEM = "navajowhite";
+const char c_HtmlNameOldLace[] PROGMEM = "oldlace";
+const char c_HtmlNameOliveDrab[] PROGMEM = "olivedrab";
+const char c_HtmlNameOrangeRed[] PROGMEM = "orangered";
+const char c_HtmlNameOrchid[] PROGMEM = "orchid";
+const char c_HtmlNamePaleGoldenrod[] PROGMEM = "palegoldenrod";
+const char c_HtmlNamePaleGreen[] PROGMEM = "palegreen";
+const char c_HtmlNamePaleTurquoise[] PROGMEM = "paleturquoise";
+const char c_HtmlNamePaleVioletRed[] PROGMEM = "palevioletred";
+const char c_HtmlNamePapayaWhip[] PROGMEM = "papayawhip";
+const char c_HtmlNamePeachPuff[] PROGMEM = "peachpuff";
+const char c_HtmlNamePeru[] PROGMEM = "peru";
+const char c_HtmlNamePink[] PROGMEM = "pink";
+const char c_HtmlNamePlum[] PROGMEM = "plum";
+const char c_HtmlNamePowderBlue[] PROGMEM = "powderblue";
+const char c_HtmlNameRosyBrown[] PROGMEM = "rosybrown";
+const char c_HtmlNameRoyalBlue[] PROGMEM = "royalblue";
+const char c_HtmlNameSaddleBrown[] PROGMEM = "saddlebrown";
+const char c_HtmlNameSalmon[] PROGMEM = "salmon";
+const char c_HtmlNameSandyBrown[] PROGMEM = "sandybrown";
+const char c_HtmlNameSeaGreen[] PROGMEM = "seagreen";
+const char c_HtmlNameSeaShell[] PROGMEM = "seashell";
+const char c_HtmlNameSienna[] PROGMEM = "sienna";
+const char c_HtmlNameSkyBlue[] PROGMEM = "skyblue";
+const char c_HtmlNameSlateBlue[] PROGMEM = "slateblue";
+const char c_HtmlNameSlateGray[] PROGMEM = "slategray";
+const char c_HtmlNameSlateGrey[] PROGMEM = "slategrey";
+const char c_HtmlNameSnow[] PROGMEM = "snow";
+const char c_HtmlNameSpringGreen[] PROGMEM = "springgreen";
+const char c_HtmlNameSteelBlue[] PROGMEM = "steelblue";
+const char c_HtmlNameTan[] PROGMEM = "tan";
+const char c_HtmlNameThistle[] PROGMEM = "thistle";
+const char c_HtmlNameTomato[] PROGMEM = "tomato";
+const char c_HtmlNameTurquoise[] PROGMEM = "turquoise";
+const char c_HtmlNameViolet[] PROGMEM = "violet";
+const char c_HtmlNameWheat[] PROGMEM = "wheat";
+const char c_HtmlNameWhiteSmoke[] PROGMEM = "whitesmoke";
+const char c_HtmlNameYellowGreen[] PROGMEM = "yellowgreen";

--- a/src/internal/HtmlColorNameStrings.h
+++ b/src/internal/HtmlColorNameStrings.h
@@ -1,0 +1,180 @@
+/*-------------------------------------------------------------------------
+HtmlColorNameStrings provides the declaration of the color string names
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/NeoPixelBus)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/NeoPixelBus library.
+
+NeoPixelBus is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+NeoPixelBus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with NeoPixel.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Arduino.h>
+
+/* HTML4 color names */
+extern const char c_HtmlNameAqua[] PROGMEM;
+extern const char c_HtmlNameBlack[] PROGMEM;
+extern const char c_HtmlNameBlue[] PROGMEM;
+extern const char c_HtmlNameFuchsia[] PROGMEM;
+extern const char c_HtmlNameGray[] PROGMEM;
+extern const char c_HtmlNameGreen[] PROGMEM;
+extern const char c_HtmlNameLime[] PROGMEM;
+extern const char c_HtmlNameMaroon[] PROGMEM;
+extern const char c_HtmlNameNavy[] PROGMEM;
+extern const char c_HtmlNameOlive[] PROGMEM;
+extern const char c_HtmlNameOrange[] PROGMEM;
+extern const char c_HtmlNamePurple[] PROGMEM;
+extern const char c_HtmlNameRed[] PROGMEM;
+extern const char c_HtmlNameSilver[] PROGMEM;
+extern const char c_HtmlNameTeal[] PROGMEM;
+extern const char c_HtmlNameWhite[] PROGMEM;
+extern const char c_HtmlNameYellow[] PROGMEM;
+
+/* Additional CSS3 color names */
+extern const char c_HtmlNameAliceBlue[] PROGMEM;
+extern const char c_HtmlNameAntiqueWhite[] PROGMEM;
+extern const char c_HtmlNameAquamarine[] PROGMEM;
+extern const char c_HtmlNameAzure[] PROGMEM;
+extern const char c_HtmlNameBeige[] PROGMEM;
+extern const char c_HtmlNameBisque[] PROGMEM;
+extern const char c_HtmlNameBlanchedAlmond[] PROGMEM;
+extern const char c_HtmlNameBlueViolet[] PROGMEM;
+extern const char c_HtmlNameBrown[] PROGMEM;
+extern const char c_HtmlNameBurlyWood[] PROGMEM;
+extern const char c_HtmlNameCadetBlue[] PROGMEM;
+extern const char c_HtmlNameChartreuse[] PROGMEM;
+extern const char c_HtmlNameChocolate[] PROGMEM;
+extern const char c_HtmlNameCoral[] PROGMEM;
+extern const char c_HtmlNameCornflowerBlue[] PROGMEM;
+extern const char c_HtmlNameCornsilk[] PROGMEM;
+extern const char c_HtmlNameCrimson[] PROGMEM;
+extern const char c_HtmlNameCyan[] PROGMEM;
+extern const char c_HtmlNameDarkBlue[] PROGMEM;
+extern const char c_HtmlNameDarkCyan[] PROGMEM;
+extern const char c_HtmlNameDarkGoldenrod[] PROGMEM;
+extern const char c_HtmlNameDarkGray[] PROGMEM;
+extern const char c_HtmlNameDarkGreen[] PROGMEM;
+extern const char c_HtmlNameDarkGrey[] PROGMEM;
+extern const char c_HtmlNameDarkKhaki[] PROGMEM;
+extern const char c_HtmlNameDarkMagenta[] PROGMEM;
+extern const char c_HtmlNameDarkOliveGreen[] PROGMEM;
+extern const char c_HtmlNameDarkOrange[] PROGMEM;
+extern const char c_HtmlNameDarkOrchid[] PROGMEM;
+extern const char c_HtmlNameDarkRed[] PROGMEM;
+extern const char c_HtmlNameDarkSalmon[] PROGMEM;
+extern const char c_HtmlNameDarkSeaGreen[] PROGMEM;
+extern const char c_HtmlNameDarkSlateBlue[] PROGMEM;
+extern const char c_HtmlNameDarkSlateGray[] PROGMEM;
+extern const char c_HtmlNameDarkSlateGrey[] PROGMEM;
+extern const char c_HtmlNameDarkTurquoise[] PROGMEM;
+extern const char c_HtmlNameDarkViolet[] PROGMEM;
+extern const char c_HtmlNameDeepPink[] PROGMEM;
+extern const char c_HtmlNameDeepSkyBlue[] PROGMEM;
+extern const char c_HtmlNameDimGray[] PROGMEM;
+extern const char c_HtmlNameDimGrey[] PROGMEM;
+extern const char c_HtmlNameDodgerBlue[] PROGMEM;
+extern const char c_HtmlNameFirebrick[] PROGMEM;
+extern const char c_HtmlNameFloralWhite[] PROGMEM;
+extern const char c_HtmlNameForestGreen[] PROGMEM;
+extern const char c_HtmlNameGainsboro[] PROGMEM;
+extern const char c_HtmlNameGhostWhite[] PROGMEM;
+extern const char c_HtmlNameGold[] PROGMEM;
+extern const char c_HtmlNameGoldenrod[] PROGMEM;
+extern const char c_HtmlNameGreenYellow[] PROGMEM;
+extern const char c_HtmlNameGrey[] PROGMEM;
+extern const char c_HtmlNameHoneydew[] PROGMEM;
+extern const char c_HtmlNameHotPink[] PROGMEM;
+extern const char c_HtmlNameIndianRed[] PROGMEM;
+extern const char c_HtmlNameIndigo[] PROGMEM;
+extern const char c_HtmlNameIvory[] PROGMEM;
+extern const char c_HtmlNameKhaki[] PROGMEM;
+extern const char c_HtmlNameLavender[] PROGMEM;
+extern const char c_HtmlNameLavenderBlush[] PROGMEM;
+extern const char c_HtmlNameLawnGreen[] PROGMEM;
+extern const char c_HtmlNameLemonChiffon[] PROGMEM;
+extern const char c_HtmlNameLightBlue[] PROGMEM;
+extern const char c_HtmlNameLightCoral[] PROGMEM;
+extern const char c_HtmlNameLightCyan[] PROGMEM;
+extern const char c_HtmlNameLightGoldenrodYellow[] PROGMEM;
+extern const char c_HtmlNameLightGray[] PROGMEM;
+extern const char c_HtmlNameLightGreen[] PROGMEM;
+extern const char c_HtmlNameLightGrey[] PROGMEM;
+extern const char c_HtmlNameLightPink[] PROGMEM;
+extern const char c_HtmlNameLightSalmon[] PROGMEM;
+extern const char c_HtmlNameLightSeaGreen[] PROGMEM;
+extern const char c_HtmlNameLightSkyBlue[] PROGMEM;
+extern const char c_HtmlNameLightSlateGray[] PROGMEM;
+extern const char c_HtmlNameLightSlateGrey[] PROGMEM;
+extern const char c_HtmlNameLightSteelBlue[] PROGMEM;
+extern const char c_HtmlNameLightYellow[] PROGMEM;
+extern const char c_HtmlNameLimeGreen[] PROGMEM;
+extern const char c_HtmlNameLinen[] PROGMEM;
+extern const char c_HtmlNameMagenta[] PROGMEM;
+extern const char c_HtmlNameMediumAquamarine[] PROGMEM;
+extern const char c_HtmlNameMediumBlue[] PROGMEM;
+extern const char c_HtmlNameMediumOrchid[] PROGMEM;
+extern const char c_HtmlNameMediumPurple[] PROGMEM;
+extern const char c_HtmlNameMediumSeagreen[] PROGMEM;
+extern const char c_HtmlNameMediumSlateBlue[] PROGMEM;
+extern const char c_HtmlNameMediumSpringGreen[] PROGMEM;
+extern const char c_HtmlNameMediumTurquoise[] PROGMEM;
+extern const char c_HtmlNameMediumVioletRed[] PROGMEM;
+extern const char c_HtmlNameMidnightBlue[] PROGMEM;
+extern const char c_HtmlNameMintCream[] PROGMEM;
+extern const char c_HtmlNameMistyRose[] PROGMEM;
+extern const char c_HtmlNameMoccasin[] PROGMEM;
+extern const char c_HtmlNameNavajoWhite[] PROGMEM;
+extern const char c_HtmlNameOldLace[] PROGMEM;
+extern const char c_HtmlNameOliveDrab[] PROGMEM;
+extern const char c_HtmlNameOrangeRed[] PROGMEM;
+extern const char c_HtmlNameOrchid[] PROGMEM;
+extern const char c_HtmlNamePaleGoldenrod[] PROGMEM;
+extern const char c_HtmlNamePaleGreen[] PROGMEM;
+extern const char c_HtmlNamePaleTurquoise[] PROGMEM;
+extern const char c_HtmlNamePaleVioletRed[] PROGMEM;
+extern const char c_HtmlNamePapayaWhip[] PROGMEM;
+extern const char c_HtmlNamePeachPuff[] PROGMEM;
+extern const char c_HtmlNamePeru[] PROGMEM;
+extern const char c_HtmlNamePink[] PROGMEM;
+extern const char c_HtmlNamePlum[] PROGMEM;
+extern const char c_HtmlNamePowderBlue[] PROGMEM;
+extern const char c_HtmlNameRosyBrown[] PROGMEM;
+extern const char c_HtmlNameRoyalBlue[] PROGMEM;
+extern const char c_HtmlNameSaddleBrown[] PROGMEM;
+extern const char c_HtmlNameSalmon[] PROGMEM;
+extern const char c_HtmlNameSandyBrown[] PROGMEM;
+extern const char c_HtmlNameSeaGreen[] PROGMEM;
+extern const char c_HtmlNameSeaShell[] PROGMEM;
+extern const char c_HtmlNameSienna[] PROGMEM;
+extern const char c_HtmlNameSkyBlue[] PROGMEM;
+extern const char c_HtmlNameSlateBlue[] PROGMEM;
+extern const char c_HtmlNameSlateGray[] PROGMEM;
+extern const char c_HtmlNameSlateGrey[] PROGMEM;
+extern const char c_HtmlNameSnow[] PROGMEM;
+extern const char c_HtmlNameSpringGreen[] PROGMEM;
+extern const char c_HtmlNameSteelBlue[] PROGMEM;
+extern const char c_HtmlNameTan[] PROGMEM;
+extern const char c_HtmlNameThistle[] PROGMEM;
+extern const char c_HtmlNameTomato[] PROGMEM;
+extern const char c_HtmlNameTurquoise[] PROGMEM;
+extern const char c_HtmlNameViolet[] PROGMEM;
+extern const char c_HtmlNameWheat[] PROGMEM;
+extern const char c_HtmlNameWhiteSmoke[] PROGMEM;
+extern const char c_HtmlNameYellowGreen[] PROGMEM;

--- a/src/internal/HtmlColorNames.cpp
+++ b/src/internal/HtmlColorNames.cpp
@@ -1,0 +1,188 @@
+/*-------------------------------------------------------------------------
+HtmlColorNames provides a template class for access to the full name table
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/NeoPixelBus)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/NeoPixelBus library.
+
+NeoPixelBus is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+NeoPixelBus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with NeoPixel.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+#include "HtmlColor.h"
+#include "HtmlColorNameStrings.h"
+
+static const HtmlColorPair c_ColorNames[] PROGMEM = {
+    { c_HtmlNameAliceBlue, 0xf0f8ff },
+    { c_HtmlNameAntiqueWhite, 0xfaebd7 },
+    { c_HtmlNameAqua, 0xffff },
+    { c_HtmlNameAquamarine, 0x7fffd4 },
+    { c_HtmlNameAzure, 0xf0ffff },
+    { c_HtmlNameBeige, 0xf5f5dc },
+    { c_HtmlNameBisque, 0xffe4c4 },
+    { c_HtmlNameBlack, 0x0 },
+    { c_HtmlNameBlanchedAlmond, 0xffebcd },
+    { c_HtmlNameBlue, 0xff },
+    { c_HtmlNameBlueViolet, 0x8a2be2 },
+    { c_HtmlNameBrown, 0xa52a2a },
+    { c_HtmlNameBurlyWood, 0xdeb887 },
+    { c_HtmlNameCadetBlue, 0x5f9ea0 },
+    { c_HtmlNameChartreuse, 0x7fff00 },
+    { c_HtmlNameChocolate, 0xd2691e },
+    { c_HtmlNameCoral, 0xff7f50 },
+    { c_HtmlNameCornflowerBlue, 0x6495ed },
+    { c_HtmlNameCornsilk, 0xfff8dc },
+    { c_HtmlNameCrimson, 0xdc143c },
+    { c_HtmlNameCyan, 0xffff },
+    { c_HtmlNameDarkBlue, 0x8b },
+    { c_HtmlNameDarkCyan, 0x8b8b },
+    { c_HtmlNameDarkGoldenrod, 0xb8860b },
+    { c_HtmlNameDarkGray, 0xa9a9a9 },
+    { c_HtmlNameDarkGreen, 0x6400 },
+    { c_HtmlNameDarkGrey, 0xa9a9a9 },
+    { c_HtmlNameDarkKhaki, 0xbdb76b },
+    { c_HtmlNameDarkMagenta, 0x8b008b },
+    { c_HtmlNameDarkOliveGreen, 0x556b2f },
+    { c_HtmlNameDarkOrange, 0xff8c00 },
+    { c_HtmlNameDarkOrchid, 0x9932cc },
+    { c_HtmlNameDarkRed, 0x8b0000 },
+    { c_HtmlNameDarkSalmon, 0xe9967a },
+    { c_HtmlNameDarkSeaGreen, 0x8fbc8f },
+    { c_HtmlNameDarkSlateBlue, 0x483d8b },
+    { c_HtmlNameDarkSlateGray, 0x2f4f4f },
+    { c_HtmlNameDarkSlateGrey, 0x2f4f4f },
+    { c_HtmlNameDarkTurquoise, 0xced1 },
+    { c_HtmlNameDarkViolet, 0x9400d3 },
+    { c_HtmlNameDeepPink, 0xff1493 },
+    { c_HtmlNameDeepSkyBlue, 0xbfff },
+    { c_HtmlNameDimGray, 0x696969 },
+    { c_HtmlNameDimGrey, 0x696969 },
+    { c_HtmlNameDodgerBlue, 0x1e90ff },
+    { c_HtmlNameFirebrick, 0xb22222 },
+    { c_HtmlNameFloralWhite, 0xfffaf0 },
+    { c_HtmlNameForestGreen, 0x228b22 },
+    { c_HtmlNameFuchsia, 0xff00ff },
+    { c_HtmlNameGainsboro, 0xdcdcdc },
+    { c_HtmlNameGhostWhite, 0xf8f8ff },
+    { c_HtmlNameGold, 0xffd700 },
+    { c_HtmlNameGoldenrod, 0xdaa520 },
+    { c_HtmlNameGray, 0x808080 },
+    { c_HtmlNameGreen, 0x8000 },
+    { c_HtmlNameGreenYellow, 0xadff2f },
+    { c_HtmlNameGrey, 0x808080 },
+    { c_HtmlNameHoneydew, 0xf0fff0 },
+    { c_HtmlNameHotPink, 0xff69b4 },
+    { c_HtmlNameIndianRed, 0xcd5c5c },
+    { c_HtmlNameIndigo, 0x4b0082 },
+    { c_HtmlNameIvory, 0xfffff0 },
+    { c_HtmlNameKhaki, 0xf0e68c },
+    { c_HtmlNameLavender, 0xe6e6fa },
+    { c_HtmlNameLavenderBlush, 0xfff0f5 },
+    { c_HtmlNameLawnGreen, 0x7cfc00 },
+    { c_HtmlNameLemonChiffon, 0xfffacd },
+    { c_HtmlNameLightBlue, 0xadd8e6 },
+    { c_HtmlNameLightCoral, 0xf08080 },
+    { c_HtmlNameLightCyan, 0xe0ffff },
+    { c_HtmlNameLightGoldenrodYellow, 0xfafad2 },
+    { c_HtmlNameLightGray, 0xd3d3d3 },
+    { c_HtmlNameLightGreen, 0x90ee90 },
+    { c_HtmlNameLightGrey, 0xd3d3d3 },
+    { c_HtmlNameLightPink, 0xffb6c1 },
+    { c_HtmlNameLightSalmon, 0xffa07a },
+    { c_HtmlNameLightSeaGreen, 0x20b2aa },
+    { c_HtmlNameLightSkyBlue, 0x87cefa },
+    { c_HtmlNameLightSlateGray, 0x778899 },
+    { c_HtmlNameLightSlateGrey, 0x778899 },
+    { c_HtmlNameLightSteelBlue, 0xb0c4de },
+    { c_HtmlNameLightYellow, 0xffffe0 },
+    { c_HtmlNameLime, 0xff00 },
+    { c_HtmlNameLimeGreen, 0x32cd32 },
+    { c_HtmlNameLinen, 0xfaf0e6 },
+    { c_HtmlNameMagenta, 0xff00ff },
+    { c_HtmlNameMaroon, 0x800000 },
+    { c_HtmlNameMediumAquamarine, 0x66cdaa },
+    { c_HtmlNameMediumBlue, 0xcd },
+    { c_HtmlNameMediumOrchid, 0xba55d3 },
+    { c_HtmlNameMediumPurple, 0x9370d8 },
+    { c_HtmlNameMediumSeagreen, 0x3cb371 },
+    { c_HtmlNameMediumSlateBlue, 0x7b68ee },
+    { c_HtmlNameMediumSpringGreen, 0xfa9a },
+    { c_HtmlNameMediumTurquoise, 0x48d1cc },
+    { c_HtmlNameMediumVioletRed, 0xc71585 },
+    { c_HtmlNameMidnightBlue, 0x191970 },
+    { c_HtmlNameMintCream, 0xf5fffa },
+    { c_HtmlNameMistyRose, 0xffe4e1 },
+    { c_HtmlNameMoccasin, 0xffe4b5 },
+    { c_HtmlNameNavajoWhite, 0xffdead },
+    { c_HtmlNameNavy, 0x80 },
+    { c_HtmlNameOldLace, 0xfdf5e6 },
+    { c_HtmlNameOlive, 0x808000 },
+    { c_HtmlNameOliveDrab, 0x6b8e23 },
+    { c_HtmlNameOrange, 0xffa500 },
+    { c_HtmlNameOrangeRed, 0xff4500 },
+    { c_HtmlNameOrchid, 0xda70d6 },
+    { c_HtmlNamePaleGoldenrod, 0xeee8aa },
+    { c_HtmlNamePaleGreen, 0x98fb98 },
+    { c_HtmlNamePaleTurquoise, 0xafeeee },
+    { c_HtmlNamePaleVioletRed, 0xd87093 },
+    { c_HtmlNamePapayaWhip, 0xffefd5 },
+    { c_HtmlNamePeachPuff, 0xffdab9 },
+    { c_HtmlNamePeru, 0xcd853f },
+    { c_HtmlNamePink, 0xffc0cb },
+    { c_HtmlNamePlum, 0xdda0dd },
+    { c_HtmlNamePowderBlue, 0xb0e0e6 },
+    { c_HtmlNamePurple, 0x800080 },
+    { c_HtmlNameRed, 0xff0000 },
+    { c_HtmlNameRosyBrown, 0xbc8f8f },
+    { c_HtmlNameRoyalBlue, 0x4169e1 },
+    { c_HtmlNameSaddleBrown, 0x8b4513 },
+    { c_HtmlNameSalmon, 0xfa8072 },
+    { c_HtmlNameSandyBrown, 0xf4a460 },
+    { c_HtmlNameSeaGreen, 0x2e8b57 },
+    { c_HtmlNameSeaShell, 0xfff5ee },
+    { c_HtmlNameSienna, 0xa0522d },
+    { c_HtmlNameSilver, 0xc0c0c0 },
+    { c_HtmlNameSkyBlue, 0x87ceeb },
+    { c_HtmlNameSlateBlue, 0x6a5acd },
+    { c_HtmlNameSlateGray, 0x708090 },
+    { c_HtmlNameSlateGrey, 0x708090 },
+    { c_HtmlNameSnow, 0xfffafa },
+    { c_HtmlNameSpringGreen, 0xff7f },
+    { c_HtmlNameSteelBlue, 0x4682b4 },
+    { c_HtmlNameTan, 0xd2b48c },
+    { c_HtmlNameTeal, 0x8080 },
+    { c_HtmlNameThistle, 0xd8bfd8 },
+    { c_HtmlNameTomato, 0xff6347 },
+    { c_HtmlNameTurquoise, 0x40e0d0 },
+    { c_HtmlNameViolet, 0xee82ee },
+    { c_HtmlNameWheat, 0xf5deb3 },
+    { c_HtmlNameWhite, 0xffffff },
+    { c_HtmlNameWhiteSmoke, 0xf5f5f5 },
+    { c_HtmlNameYellow, 0xffff00 },
+    { c_HtmlNameYellowGreen, 0x9acd32 },
+};
+
+const HtmlColorPair* HtmlColorNames::Pair(uint8_t index)
+{
+    return &c_ColorNames[index];
+}
+
+uint8_t HtmlColorNames::Count()
+{
+    return countof(c_ColorNames);
+}

--- a/src/internal/HtmlColorShortNames.cpp
+++ b/src/internal/HtmlColorShortNames.cpp
@@ -1,7 +1,7 @@
 /*-------------------------------------------------------------------------
-This file contains the HtmlColor implementation
+HtmlShortColorNames provides a template class for access to the short name table
 
-Written by Unai Uribarri
+Written by Michael C. Miller.
 
 I invest time and resources providing this open source code,
 please support me by dontating (see https://github.com/Makuna/NeoPixelBus)
@@ -23,36 +23,37 @@ You should have received a copy of the GNU Lesser General Public
 License along with NeoPixel.  If not, see
 <http://www.gnu.org/licenses/>.
 -------------------------------------------------------------------------*/
-#include "HtmlColor.h"
 
-static inline char hexdigit(uint8_t v)
+#include "HtmlColor.h"
+#include "HtmlColorNameStrings.h"
+
+static const HtmlColorPair c_ShortColorNames[] PROGMEM = {
+    { c_HtmlNameAqua, 0xffff },
+    { c_HtmlNameBlack, 0x0 },
+    { c_HtmlNameBlue, 0xff },
+    { c_HtmlNameFuchsia, 0xff00ff },
+    { c_HtmlNameGray, 0x808080 },
+    { c_HtmlNameGreen, 0x8000 },
+    { c_HtmlNameLime, 0xff00 },
+    { c_HtmlNameMaroon, 0x800000 },
+    { c_HtmlNameNavy, 0x80 },
+    { c_HtmlNameOlive, 0x808000 },
+    { c_HtmlNameOrange, 0xffa500 },
+    { c_HtmlNamePurple, 0x800080 },
+    { c_HtmlNameRed, 0xff0000 },
+    { c_HtmlNameSilver, 0xc0c0c0 },
+    { c_HtmlNameTeal, 0x8080 },
+    { c_HtmlNameWhite, 0xffffff },
+    { c_HtmlNameYellow, 0xffff00 },
+};
+
+
+const HtmlColorPair* HtmlShortColorNames::Pair(uint8_t index)
 {
-    return v + (v < 10 ? '0' : 'a' - 10);
+    return &c_ShortColorNames[index];
 }
 
-
-size_t HtmlColor::ToNumericalString(char* buf, size_t bufSize) const
+uint8_t HtmlShortColorNames::Count()
 {
-    size_t bufLen = bufSize - 1;
-
-    if (bufLen-- > 0)
-    {
-        if (bufLen > 0)
-        {
-            buf[0] = '#';
-        }
-
-        uint32_t color = Color;
-        for (uint8_t indexDigit = 6; indexDigit > 0; indexDigit--)
-        {
-            if (bufLen > indexDigit)
-            {
-                buf[indexDigit] = hexdigit(color & 0x0000000f);
-            }
-            color >>= 4;
-        }
-
-        buf[min(bufLen, 7)] = 0;
-    }
-    return 7;
+    return countof(c_ShortColorNames);
 }


### PR DESCRIPTION
Accessing the extended string names no longer requires editing a library
header file.