### PR TITLE
DotStar and NoPin NeoPixel

### DIFF
--- a/examples/NeoPixelAnimation/NeoPixelAnimation.ino
+++ b/examples/NeoPixelAnimation/NeoPixelAnimation.ino
@@ -26,14 +26,13 @@ const uint16_t PixelCount = 4; // make sure to set this to the number of pixels 
 const uint8_t PixelPin = 2;  // make sure to set this to the correct pin, ignored for Esp8266
 
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
-// For Esp8266, the Pin is ignored and it uses GPIO3.  
+// For Esp8266, the Pin is omitted and it uses GPIO3 due to DMA hardware use.  
 // There are other Esp8266 alternative methods that provide more pin options, but also have
 // other side effects.
-//NeoPixelBus<NeoGrbFeature, NeoEsp8266Uart800KbpsMethod> strip(PixelCount, PixelPin);
-// NeoEsp8266Uart800KbpsMethod also ignores the pin parameter and uses GPI02
-//NeoPixelBus<NeoGrbFeature, NeoEsp8266BitBang800KbpsMethod> strip(PixelCount, PixelPin);
-// NeoEsp8266Uart800KbpsMethod will work with all but pin 16, but is not stable with WiFi 
-// being active
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
+//
+// NeoEsp8266Uart800KbpsMethod uses GPI02 instead
+
 
 // NeoPixel animation time management object
 NeoPixelAnimator animations(PixelCount, NEO_CENTISECONDS);

--- a/examples/NeoPixelBitmap/NeoPixelBitmap.ino
+++ b/examples/NeoPixelBitmap/NeoPixelBitmap.ino
@@ -24,6 +24,8 @@ const uint16_t PixelPin = 2;
 const uint16_t AnimCount = 1; // we only need one
 
 NeoPixelBus<MyPixelColorFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+// for esp8266 omit the pin
+//NeoPixelBus<MyPixelColorFeature, Neo800KbpsMethod> strip(PixelCount);
 NeoPixelAnimator animations(AnimCount); // NeoPixel animation management object
 
 // our NeoBitmapFile will use the same color feature as NeoPixelBus and

--- a/examples/NeoPixelBufferCylon/NeoPixelBufferCylon.ino
+++ b/examples/NeoPixelBufferCylon/NeoPixelBufferCylon.ino
@@ -23,6 +23,8 @@ const uint16_t PixelPin = 2;
 const uint16_t AnimCount = 1; // we only need one
 
 NeoPixelBus<MyPixelColorFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+// for esp8266 omit the pin
+//NeoPixelBus<MyPixelColorFeature, Neo800KbpsMethod> strip(PixelCount);
 NeoPixelAnimator animations(AnimCount); // NeoPixel animation management object
 
 // sprite sheet stored in progmem using the same pixel feature as the NeoPixelBus

--- a/examples/NeoPixelCylon/NeoPixelCylon.ino
+++ b/examples/NeoPixelCylon/NeoPixelCylon.ino
@@ -15,6 +15,8 @@ const uint8_t PixelPin = 2;  // make sure to set this to the correct pin, ignore
 const RgbColor CylonEyeColor(HtmlColor(0x7f0000));
 
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+// for esp8266 omit the pin
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
 
 NeoPixelAnimator animations(2); // only ever need 2 animations
 

--- a/examples/NeoPixelFunFadeInOut/NeoPixelFunFadeInOut.ino
+++ b/examples/NeoPixelFunFadeInOut/NeoPixelFunFadeInOut.ino
@@ -13,14 +13,12 @@ const uint8_t PixelPin = 2;  // make sure to set this to the correct pin, ignore
 const uint8_t AnimationChannels = 1; // we only need one as all the pixels are animated at once
 
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
-// For Esp8266, the Pin is ignored and it uses GPIO3.  
+// For Esp8266, the Pin is omitted and it uses GPIO3 due to DMA hardware use.  
 // There are other Esp8266 alternative methods that provide more pin options, but also have
 // other side effects.
-//NeoPixelBus<NeoGrbFeature, NeoEsp8266Uart800KbpsMethod> strip(PixelCount, PixelPin);
-// NeoEsp8266Uart800KbpsMethod also ignores the pin parameter and uses GPI02
-//NeoPixelBus<NeoGrbFeature, NeoEsp8266BitBang800KbpsMethod> strip(PixelCount, PixelPin);
-// NeoEsp8266Uart800KbpsMethod will work with all but pin 16, but is not stable with WiFi 
-// being active
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
+//
+// NeoEsp8266Uart800KbpsMethod uses GPI02 instead
 
 NeoPixelAnimator animations(AnimationChannels); // NeoPixel animation management object
 

--- a/examples/NeoPixelFunLoop/NeoPixelFunLoop.ino
+++ b/examples/NeoPixelFunLoop/NeoPixelFunLoop.ino
@@ -26,14 +26,12 @@ const uint16_t NextPixelMoveDuration = 1000 / PixelCount; // how fast we move th
 NeoGamma<NeoGammaTableMethod> colorGamma; // for any fade animations, best to correct gamma
 
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
-// For Esp8266, the Pin is ignored and it uses GPIO3.  
+// For Esp8266, the Pin is omitted and it uses GPIO3 due to DMA hardware use.  
 // There are other Esp8266 alternative methods that provide more pin options, but also have
 // other side effects.
-//NeoPixelBus<NeoGrbFeature, NeoEsp8266Uart800KbpsMethod> strip(PixelCount, PixelPin);
-// NeoEsp8266Uart800KbpsMethod also ignores the pin parameter and uses GPI02
-//NeoPixelBus<NeoGrbFeature, NeoEsp8266BitBang800KbpsMethod> strip(PixelCount, PixelPin);
-// NeoEsp8266BitBang800KbpsMethod will work with all but pin 16, but is not stable with WiFi 
-// being active
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
+//
+// NeoEsp8266Uart800KbpsMethod uses GPI02 instead
 
 // what is stored for state is specific to the need, in this case, the colors and
 // the pixel to animate;

--- a/examples/NeoPixelFunRandomChange/NeoPixelFunRandomChange.ino
+++ b/examples/NeoPixelFunRandomChange/NeoPixelFunRandomChange.ino
@@ -11,14 +11,12 @@ const uint16_t PixelCount = 16; // make sure to set this to the number of pixels
 const uint8_t PixelPin = 2;  // make sure to set this to the correct pin, ignored for Esp8266
 
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
-// For Esp8266, the Pin is ignored and it uses GPIO3.  
+// For Esp8266, the Pin is omitted and it uses GPIO3 due to DMA hardware use.  
 // There are other Esp8266 alternative methods that provide more pin options, but also have
 // other side effects.
-//NeoPixelBus<NeoGrbFeature, NeoEsp8266Uart800KbpsMethod> strip(PixelCount, PixelPin);
-// NeoEsp8266Uart800KbpsMethod also ignores the pin parameter and uses GPI02
-//NeoPixelBus<NeoGrbFeature, NeoEsp8266BitBang800KbpsMethod> strip(PixelCount, PixelPin);
-// NeoEsp8266Uart800KbpsMethod will work with all but pin 16, but is not stable with WiFi 
-// being active
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
+//
+// NeoEsp8266Uart800KbpsMethod uses GPI02 instead
 
 NeoPixelAnimator animations(PixelCount); // NeoPixel animation management object
 

--- a/examples/NeoPixelGamma/NeoPixelGamma.ino
+++ b/examples/NeoPixelGamma/NeoPixelGamma.ino
@@ -16,6 +16,8 @@ const uint16_t PixelCount = 16; // make sure to set this to the number of pixels
 const uint8_t PixelPin = 2;  // make sure to set this to the correct pin, ignored for Esp8266
 
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+// for esp8266 omit the pin
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
 
 // uncomment only one of these to compare memory use or speed
 //

--- a/examples/NeoPixelMosaicTest/NeoPixelMosaicTest.ino
+++ b/examples/NeoPixelMosaicTest/NeoPixelMosaicTest.ino
@@ -36,8 +36,8 @@ NeoMosaic <MyPanelLayout> mosaic(
     TileHeight);
 
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
-//NeoPixelBus<NeoRgbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
-//NeoPixelBus<NeoRgbwFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+// for esp8266 omit the pin
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
 
 RgbColor red(128, 0, 0);
 RgbColor green(0, 128, 0);

--- a/examples/NeoPixelRotateLoop/NeoPixelRotateLoop.ino
+++ b/examples/NeoPixelRotateLoop/NeoPixelRotateLoop.ino
@@ -19,7 +19,8 @@ const float MaxLightness = 0.4f; // max lightness at the head of the tail (0.5f 
 NeoGamma<NeoGammaTableMethod> colorGamma; // for any fade animations, best to correct gamma
 
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
-//NeoPixelBus<NeoGrbwFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+// for esp8266 omit the pin
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
 
 NeoPixelAnimator animations(AnimCount); // NeoPixel animation management object
 

--- a/examples/NeoPixelTest/NeoPixelTest.ino
+++ b/examples/NeoPixelTest/NeoPixelTest.ino
@@ -22,6 +22,13 @@ const uint8_t PixelPin = 2;  // make sure to set this to the correct pin, ignore
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
 //NeoPixelBus<NeoRgbFeature, Neo400KbpsMethod> strip(PixelCount, PixelPin);
 
+// For Esp8266, the Pin is omitted and it uses GPIO3 due to DMA hardware use.  
+// There are other Esp8266 alternative methods that provide more pin options, but also have
+// other side effects.
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
+//
+// NeoEsp8266Uart800KbpsMethod uses GPI02 instead
+
 // You can also use one of these for Esp8266, 
 // each having their own restrictions
 //

--- a/examples/NeoPixelTilesTest/NeoPixelTilesTest.ino
+++ b/examples/NeoPixelTilesTest/NeoPixelTilesTest.ino
@@ -42,6 +42,8 @@ NeoTiles <MyPanelLayout, MyTilesLayout> tiles(
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
 //NeoPixelBus<NeoRgbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
 //NeoPixelBus<NeoRgbwFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+// for esp8266 omit the pin
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
 
 RgbColor red(128, 0, 0);
 RgbColor green(0, 128, 0);

--- a/examples/NeoPixelTopologyTest/NeoPixelTopologyTest.ino
+++ b/examples/NeoPixelTopologyTest/NeoPixelTopologyTest.ino
@@ -31,6 +31,8 @@ NeoTopology<MyPanelLayout> topo(PanelWidth, PanelHeight);
 NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
 //NeoPixelBus<NeoRgbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
 //NeoPixelBus<NeoRgbwFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+// for esp8266 omit the pin
+//NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(PixelCount);
 
 RgbColor red(128, 0, 0);
 RgbColor green(0, 128, 0);

--- a/library.json
+++ b/library.json
@@ -1,14 +1,14 @@
 {
   "name": "NeoPixelBus",
   "keywords": "NeoPixel, WS2811, WS2812, SK6812, DotStar, ADA102, RGB, RGBW",
-  "description": "A library that makes controlling NeoPixels (WS2811, WS2812 & SK6812) and DotStars (ADA102) easy.  Supports most Arduino platforms.  Support for RGBW pixels.  Includes seperate RgbColor, RgbwColor, HslColor, and HsbColor objects.  Includes an animator class that helps create asyncronous animations.  For Esp8266 it has three methods of sending data, DMA, UART, and Bit Bang.",
+  "description": "A library that makes controlling NeoPixels (WS2811, WS2812 & SK6812) and DotStars (ADA102) easy.  Supports most Arduino platforms.  Support for RGBW pixels.  Includes seperate RgbColor, RgbwColor, HslColor, and HsbColor objects.  Includes an animator class that helps create asyncronous animations.  For Esp8266 it has three methods of sending NeoPixel data, DMA, UART, and Bit Bang; and two methods of sending DotStar data, hardware SPI and software SPI.",
   "homepage": "https://github.com/Makuna/NeoPixelBus/wiki",
   "repository":
   {
     "type": "git",
     "url": "https://github.com/Makuna/NeoPixelBus"
   },
-  "version": "2.2.0",
+  "version": "2.2.1",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=NeoPixelBus by Makuna
-version=2.2.0
+version=2.2.1
 author=Michael C. Miller (makuna@live.com)
 maintainer=Michael C. Miller (makuna@live.com)
 sentence=A library that makes controlling NeoPixels (WS2811, WS2812 & SK6812) and DotStars (ADA102) easy.
-paragraph=Supports most Arduino platforms, and especially Esp8266.  Support for RGBW pixels.  Includes seperate RgbColor, RgbwColor, HslColor, and HsbColor objects.  Includes an animator class that helps create asyncronous animations.  Supports Matrix layout of pixels.  Includes Gamma corretion object.  For Esp8266 it has three methods of sending data, DMA, UART, and Bit Bang. 
+paragraph=Supports most Arduino platforms, and especially Esp8266.  Support for RGBW pixels.  Includes seperate RgbColor, RgbwColor, HslColor, and HsbColor objects.  Includes an animator class that helps create asyncronous animations.  Supports Matrix layout of pixels.  Includes Gamma corretion object.  For Esp8266 it has three methods of sending NeoPixel data, DMA, UART, and Bit Bang; and two methods of sending DotStar data, hardware SPI and software SPI.
 category=Display
 url=https://github.com/Makuna/NeoPixelBus/wiki
 architectures=*

--- a/src/internal/DotStarSpiMethod.h
+++ b/src/internal/DotStarSpiMethod.h
@@ -54,7 +54,7 @@ public:
         SPI.begin();
 
 #if defined(ARDUINO_ARCH_ESP8266)
-        SPI.setFrequency(8000000L);
+        SPI.setFrequency(20000000L);
 #elif defined(ARDUINO_ARCH_AVR) 
         SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
 #else

--- a/src/internal/NeoEsp8266DmaMethod.h
+++ b/src/internal/NeoEsp8266DmaMethod.h
@@ -91,7 +91,7 @@ const uint8_t c_I2sPin = 3; // due to I2S hardware, the pin used is restricted t
 template<typename T_SPEED> class NeoEsp8266DmaMethodBase
 {
 public:
-    NeoEsp8266DmaMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize) 
+    NeoEsp8266DmaMethodBase(uint16_t pixelCount, size_t elementSize) 
     {
         uint16_t dmaPixelSize = c_dmaBytesPerPixelBytes * elementSize;
 

--- a/src/internal/NeoEsp8266UartMethod.cpp
+++ b/src/internal/NeoEsp8266UartMethod.cpp
@@ -54,7 +54,7 @@ static inline void enqueue(uint8_t byte)
 static const uint8_t* esp8266_uart1_async_buf;
 static const uint8_t* esp8266_uart1_async_buf_end;
 
-NeoEsp8266Uart::NeoEsp8266Uart(uint8_t pin, uint16_t pixelCount, size_t elementSize)
+NeoEsp8266Uart::NeoEsp8266Uart(uint16_t pixelCount, size_t elementSize)
 {
     _sizePixels = pixelCount * elementSize;
     _pixels = (uint8_t*)malloc(_sizePixels);
@@ -130,8 +130,8 @@ const uint8_t* ICACHE_RAM_ATTR NeoEsp8266Uart::FillUartFifo(const uint8_t* pixel
     return pixels;
 }
 
-NeoEsp8266AsyncUart::NeoEsp8266AsyncUart(uint8_t pin, uint16_t pixelCount, size_t elementSize)
-    : NeoEsp8266Uart(pin, pixelCount, elementSize)
+NeoEsp8266AsyncUart::NeoEsp8266AsyncUart(uint16_t pixelCount, size_t elementSize)
+    : NeoEsp8266Uart(pixelCount, elementSize)
 {
     _asyncPixels = (uint8_t*)malloc(_sizePixels);
 }

--- a/src/internal/NeoEsp8266UartMethod.h
+++ b/src/internal/NeoEsp8266UartMethod.h
@@ -34,7 +34,7 @@ License along with NeoPixel.  If not, see
 class NeoEsp8266Uart
 {
 protected:
-    NeoEsp8266Uart(uint8_t pin, uint16_t pixelCount, size_t elementSize);
+    NeoEsp8266Uart(uint16_t pixelCount, size_t elementSize);
 
     ~NeoEsp8266Uart();
 
@@ -61,7 +61,7 @@ protected:
 class NeoEsp8266AsyncUart: public NeoEsp8266Uart
 {
 protected:
-    NeoEsp8266AsyncUart(uint8_t pin, uint16_t pixelCount, size_t elementSize);
+    NeoEsp8266AsyncUart(uint16_t pixelCount, size_t elementSize);
 
     ~NeoEsp8266AsyncUart();
 
@@ -97,8 +97,8 @@ template<typename T_SPEED, typename T_BASE>
 class NeoEsp8266UartMethodBase: public T_BASE
 {
 public:
-    NeoEsp8266UartMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize)
-        : T_BASE(pin, pixelCount, elementSize)
+    NeoEsp8266UartMethodBase(uint16_t pixelCount, size_t elementSize)
+        : T_BASE(pixelCount, elementSize)
     {
     }
 


### PR DESCRIPTION
removed the need to provide the pin argument for Esp8266 NeoPixelBus
where it was ignored.
Added another DotStar color feature.
Fixed DotStar color features to use RgbColor when there is no need for
RgbwColor.