### PR TITLE
NeoPixelAnimator class updated to include setDuration and setProgress

### DIFF
--- a/examples/animations/NeoPixelChangeDuration/NeoPixelChangeDuration.ino
+++ b/examples/animations/NeoPixelChangeDuration/NeoPixelChangeDuration.ino
@@ -1,0 +1,117 @@
+// NeoPixelChangeDuration
+// This example will demonstrate the NeoPixelAnimator::setDuration
+// function to change the duration of a simple color fading
+// application without the need to restart the animation from time 0. 
+// Useful if you would like an animation to speed up/slow down based on 
+// user input. 
+// This example also showcases some gamma fading techniques that are provided
+// by the library. 
+// A small comment is made towards the end of this example regarding how to arbitrarily set the progress of an animation, using the NeoPixelAnimator::setProgress() function call
+
+// See the NeoPixelAnimation.ino example for more information on
+// how to use the base NeoPixelAnimator class effectively
+
+// Tested on the adafruit circuit playground, but should be usable 
+// on other platforms as well
+//
+// Written by Nigel Michki <nigeil@yahoo.com>
+
+
+// =====Library includes=====
+#include <NeoPixelBus.h>
+#include <NeoPixelAnimator.h>
+#include <Arduino.h>
+
+
+// =====Definitions=====
+// define the number of pixels
+#define N_PIXELS 10		// for original circuit playground; change as needed
+#define NEOPIXEL_PIN 17 // for original circuit playground; change as needed
+#define ANIMATION_COUNT 1 // only one animation
+
+// A list of reasonable animation durations (here, in NEO_CENTISECONDS, based on the NeoPixelBus speed selected below)
+const int durations[6] = {700, 1000, 1400, 2500, 3250, 4000};
+
+
+// =====Important declarations=====
+// The index we'll use to keep track of the currently selected duration
+uint16_t duration_ind;
+
+// make the neopixel bus/driver
+NeoPixelBus<NeoGrbFeature, Neo800KbpsMethod> strip(N_PIXELS, NEOPIXEL_PIN);
+
+// and the animation handler
+NeoPixelAnimator animate_me(ANIMATION_COUNT, NEO_CENTISECONDS);
+
+// We're going to use gamma correction here to fade the pixel
+// colors in a 'truer' fashion
+NeoGamma<NeoGammaTableMethod> color_gamma;
+
+// The current time; we'll use this to decide when to update the animation
+// duration in this example in an arbitrary/semi-random fashion
+uint16_t current_time;
+
+// =====Helper functions=====
+// Define the animation update callback function
+void RainbowGammaFadeAnimationUpdate(const AnimationParam& param) {
+	RgbColor current_color; 
+	float current_progress;
+
+	// calculate the current progress based on a 'gamma' easing equation (not necessary, but looks the most natural for a gamma-corrected set of colors)
+	current_progress = NeoEase::Gamma(param.progress);
+	
+	// calculate the current color based on a linear blend between the same HSL color (a light purple) around the longest possible distance
+	current_color = RgbColor(HslColor::LinearBlend<NeoHueBlendLongestDistance>(HslColor(0.88f,1.0f,0.5f), HslColor(0.88f,1.0f,0.5f), current_progress));
+	
+	// and gamma correct this color (can be combined with the previous step)
+	current_color = color_gamma.Correct(current_color);
+
+	// update the pixel colors
+  	for (int i=0; i<N_PIXELS; i++){
+    	strip.SetPixelColor(i, current_color);
+  	}
+}
+
+
+// =====Setup=====
+void setup() {
+	// Set the neopixel pin as an output
+	pinMode(NEOPIXEL_PIN, OUTPUT);
+
+	// sane starting duration index
+	duration_ind = 0;
+
+	// Start the neopixel animation up (animation 0)
+	strip.Begin();
+	animate_me.StartAnimation(0, durations[duration_ind], RainbowGammaFadeAnimationUpdate);
+
+}
+
+
+// =====Main program loop=====
+void loop() {
+	// get the 'current time'
+	current_time = (millis() % 1000);
+
+	// check if the animation has ended; restart if this is the case
+	if (animate_me.IsAnimating() == false){
+		animate_me.StopAnimation(0);
+		animate_me.StartAnimation(0, durations[duration_ind], RainbowGammaFadeAnimationUpdate);
+	}
+
+	// this is an arbitrary update condition, but you should see changes to
+	// the duration every time millis() % 1000 == 0
+	// (recommended: hook up a push button and change this duration when 
+	//  the button is pushed - much more interesting)
+	if (current_time == 0) {
+		duration_ind = (duration_ind + 1) % 6; // pick the next duration (6 options)
+		
+		// updates the animation duration without changing its current progress
+		animate_me.setDuration(0, durations[duration_ind]); 
+		
+		// To instead change the progress of an animation directly, use the NeoPixelAnimator::setProgress(uint16_t animationIndex, float newProgress) function call, providing a newProgress value in the range [0,1].
+	}
+
+	animate_me.UpdateAnimations();
+	strip.Show();
+}

--- a/src/NeoPixelAnimator.h
+++ b/src/NeoPixelAnimator.h
@@ -6,6 +6,7 @@ Written by Michael C. Miller.
 I invest time and resources providing this open source code,
 please support me by dontating (see https://github.com/Makuna/NeoPixelBus)
 
+Contributors: Nigel Michki <nigeil@yahoo.com>
 -------------------------------------------------------------------------
 This file is part of the Makuna/NeoPixelBus library.
 
@@ -136,6 +137,12 @@ public:
     {
         _timeScale = (timeScale < 1) ? (1) : (timeScale > 32768) ? 32768 : timeScale;
     }
+
+    void setDuration(uint16_t indexAnimation, uint16_t newDuration);
+
+    void setProgress(uint16_t indexAnimation, float newProgress);
+
+    float getProgress(uint16_t indexAnimation);
 
 private:
     struct AnimationContext

--- a/src/internal/NeoPixelAnimator.cpp
+++ b/src/internal/NeoPixelAnimator.cpp
@@ -6,6 +6,7 @@ Written by Michael C. Miller.
 I invest time and resources providing this open source code,
 please support me by dontating (see https://github.com/Makuna/NeoPixelBus)
 
+Contributors: Nigel Michki <nigeil@yahoo.com>
 -------------------------------------------------------------------------
 This file is part of the Makuna/NeoPixelBus library.
 
@@ -162,5 +163,50 @@ void NeoPixelAnimator::UpdateAnimations()
 
             _animationLastTick = currentTick;
         }
+    }
+}
+
+void NeoPixelAnimator::setDuration(uint16_t indexAnimation, uint16_t newDuration)
+{
+    if(indexAnimation >= _countAnimations) { return; } //invalid animation index
+    else 
+    {
+        // get the current animation progress
+        float current_progress = getProgress(indexAnimation);
+
+        // change the duration
+        AnimationContext* pAnim;
+        pAnim = &_animations[indexAnimation];
+        pAnim->_duration = newDuration;
+
+        // _remaining time must also be reset after a duration change; use the original progress to make this change
+        setProgress(indexAnimation, current_progress);
+    }
+}
+
+// actually sets the _remaining ticks left for an animation in its AnimationContext using the progress provided here
+void NeoPixelAnimator::setProgress(uint16_t indexAnimation, float newProgress)
+{
+    if(indexAnimation >= _countAnimations) { return; } //invalid animation index
+    else 
+    {
+        AnimationContext* pAnim;
+        pAnim = &_animations[indexAnimation];
+        if(newProgress > 1 || newProgress < 0) { return; } //can't have a progress beyond the animation's duration (1) or a negative progress
+        uint16_t newRemaining = uint16_t(pAnim->_duration * (1.0 - newProgress));
+        pAnim->_remaining = newRemaining;
+    }
+}   
+
+float NeoPixelAnimator::getProgress(uint16_t indexAnimation) 
+{
+    if(indexAnimation >= _countAnimations) { return -1.0; } //invalid animation index
+    else 
+    {
+        AnimationContext* pAnim;        
+        float progress = 0;
+        pAnim = &_animations[indexAnimation];
+        progress = (float)(pAnim->_duration - pAnim->_remaining) / (float)pAnim->_duration;
+        return progress;
     }
 }


### PR DESCRIPTION
NeoPixelAnimator class updated to include setDuration and setProgress, getProgress methods, in order to dynamically set the animation duration
without the need to restart the animation from progress 0. An example,
NeoPixelChangeDuration.ino, also added to showcase this new
functionality. Tested on an Adafruit circuit playground (original).
Contributor line added to NeoPixelAnimator.h/cpp as well.