### PR TITLE
Added RMT method for ESP32

### DIFF
--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -72,6 +72,7 @@ License along with NeoPixel.  If not, see
 #elif defined(ARDUINO_ARCH_ESP32)
 
 #include "internal/NeoEspBitBangMethod.h"
+#include "internal/NeoEspRmtMethod.h"
 #include "internal/DotStarGenericMethod.h"
 
 #elif defined(__arm__) // must be before ARDUINO_ARCH_AVR due to Teensy incorrectly having it set

--- a/src/internal/NeoEspRmtMethod.h
+++ b/src/internal/NeoEspRmtMethod.h
@@ -69,7 +69,7 @@ class NeoEspRmtMethodImpl
 {
 public:
 
-    NeoEspRmtMethodImpl(uint8_t pin, uint16_t pixelCount, size_t elementSize, int ledType)
+    NeoEspRmtMethodImpl(uint8_t pin, uint16_t pixelCount, size_t elementSize, int ledType, rmt_channel_t channel = RMT_CHANNEL_MAX)
         : _gpioNum(pin)
         , _sizePixels(pixelCount * elementSize)
         , _pixels(nullptr)
@@ -81,18 +81,26 @@ public:
             _pixels = (uint8_t*)malloc(_sizePixels);
             memset(_pixels, 0, _sizePixels);
 
-            // Find a free channel
-            for (int i = RMT_CHANNEL_0; i < RMT_CHANNEL_MAX; ++i)
+            if (channel != RMT_CHANNEL_MAX)
             {
-                auto c = static_cast<rmt_channel_t>(i);
-
-                if (s_channels.find(c) == s_channels.end())
+                // RMT channel has been provided, use it!
+                _rmtChannel = channel;
+            }
+            else
+            {
+                // No channel given, find a free channel
+                for (int i = RMT_CHANNEL_0; i < RMT_CHANNEL_MAX; ++i)
                 {
-                    s_channels.insert(c);
-                    _rmtChannel = c;
-                    break;
+                    auto c = static_cast<rmt_channel_t>(i);
+
+                    if (s_channels.find(c) == s_channels.end())
+                    {
+                        _rmtChannel = c;
+                        break;
+                    }
                 }
             }
+            s_channels.insert(_rmtChannel);
         }
 
     ~NeoEspRmtMethodImpl()
@@ -174,7 +182,7 @@ public:
             return _impl.getPixelsSize();
         };
 
- private:
+private:
     NeoEspRmtMethodImpl _impl;
 };
 

--- a/src/internal/NeoEspRmtMethod.h
+++ b/src/internal/NeoEspRmtMethod.h
@@ -1,0 +1,198 @@
+/*-------------------------------------------------------------------------
+  NeoPixel library base on RMT for Esp32
+
+  Written by Sven Fischer.
+  RMT code copied from Neil Kolban
+  Original from https://github.com/nkolban/esp32-snippets/blob/master/cpp_utils/WS2812.cpp
+
+  -------------------------------------------------------------------------
+  This file is part of the Makuna/NeoPixelBus library.
+
+  NeoPixelBus is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of
+  the License, or (at your option) any later version.
+
+  NeoPixelBus is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with NeoPixel.  If not, see
+  <http://www.gnu.org/licenses/>.
+  -------------------------------------------------------------------------*/
+
+#pragma once
+
+#if defined(ARDUINO_ARCH_ESP32)
+
+#include <stdint.h>
+#include <driver/rmt.h>
+#include <set>
+
+namespace detail {
+
+    enum led_types {
+        // LED_WS2812_V1,
+        // LED_WS2812B_V1,
+        // LED_WS2812B_V2,
+        // LED_WS2812B_V3,
+        // LED_WS2813_V1,
+        // LED_WS2813_V2,
+        LED_WS2813_V3,
+        // LED_SK6812_V1,
+        // LED_SK6812W_V1,
+    };
+    typedef struct {
+        uint32_t T0H;
+        uint32_t T1H;
+        uint32_t T0L;
+        uint32_t T1L;
+    } ledParams_t;
+
+    const ledParams_t ledParamsAll[] = {  // Still must match order of `led_types`
+        // [LED_WS2812_V1]  = { .bytesPerPixel = 3, .T0H = 350, .T1H = 700, .T0L = 800, .T1L = 600, .TRS =  50000},
+        // [LED_WS2812B_V1] = { .bytesPerPixel = 3, .T0H = 350, .T1H = 900, .T0L = 900, .T1L = 350, .TRS =  50000}, // Older datasheet
+        // [LED_WS2812B_V2] = { .bytesPerPixel = 3, .T0H = 400, .T1H = 850, .T0L = 850, .T1L = 400, .TRS =  50000}, // 2016 datasheet
+        // [LED_WS2812B_V3] = { .bytesPerPixel = 3, .T0H = 450, .T1H = 850, .T0L = 850, .T1L = 450, .TRS =  50000}, // cplcpu test
+        // [LED_WS2813_V1]  = { .bytesPerPixel = 3, .T0H = 350, .T1H = 800, .T0L = 350, .T1L = 350, .TRS = 300000}, // Older datasheet
+        // [LED_WS2813_V2]  = { .bytesPerPixel = 3, .T0H = 270, .T1H = 800, .T0L = 800, .T1L = 270, .TRS = 300000}, // 2016 datasheet
+        [LED_WS2813_V3]  = { .T0H = 4, .T1H = 10, .T0L = 8, .T1L = 6 }, // 2017-05 WS datasheet
+        // [LED_SK6812_V1]  = { .bytesPerPixel = 3, .T0H = 300, .T1H = 600, .T0L = 900, .T1L = 600, .TRS =  80000},
+        // [LED_SK6812W_V1] = { .bytesPerPixel = 4, .T0H = 300, .T1H = 600, .T0L = 900, .T1L = 600, .TRS =  80000},
+    };
+}
+
+
+class NeoEspRmtMethodImpl
+{
+public:
+
+    NeoEspRmtMethodImpl(uint8_t pin, uint16_t pixelCount, size_t elementSize, int ledType)
+        : _gpioNum(pin)
+        , _sizePixels(pixelCount * elementSize)
+        , _pixels(nullptr)
+        , _ledType(ledType)
+        {
+            pinMode(pin, OUTPUT);
+
+            _sizePixels = pixelCount * elementSize;
+            _pixels = (uint8_t*)malloc(_sizePixels);
+            memset(_pixels, 0, _sizePixels);
+
+            // Find a free channel
+            for (int i = RMT_CHANNEL_0; i < RMT_CHANNEL_MAX; ++i)
+            {
+                auto c = static_cast<rmt_channel_t>(i);
+
+                if (s_channels.find(c) == s_channels.end())
+                {
+                    s_channels.insert(c);
+                    _rmtChannel = c;
+                    break;
+                }
+            }
+        }
+
+    ~NeoEspRmtMethodImpl()
+        {
+            pinMode(_gpioNum, INPUT);
+
+            free(_pixels);
+            s_channels.erase(s_channels.find(_rmtChannel));
+        }
+
+    bool IsReadyToUpdate() const
+        {
+            return true;
+        }
+
+    void Initialize();
+
+    void Update();
+
+    uint8_t* getPixels() const
+        {
+            return _pixels;
+        };
+
+    size_t getPixelsSize() const
+        {
+            return _sizePixels;
+        };
+
+
+private:
+    size_t    _sizePixels;   // Size of '_pixels' buffer below
+    uint8_t*  _pixels;        // Holds LED color values
+
+    rmt_channel_t _rmtChannel;
+    rmt_item32_t *_items{nullptr};
+    int       _gpioNum;
+    int       _ledType;
+
+    static std::set<rmt_channel_t> s_channels;
+};
+
+
+template<int T_LEDTYPE> class NeoEspRmtMethodBase
+{
+public:
+
+    NeoEspRmtMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize) :
+        _impl(pin, pixelCount, elementSize, T_LEDTYPE)
+        {
+        }
+
+    ~NeoEspRmtMethodBase()
+        {
+        }
+
+    bool IsReadyToUpdate() const
+        {
+            return _impl.IsReadyToUpdate();
+        }
+
+    void Initialize()
+        {
+            _impl.Initialize();
+        }
+
+    void Update()
+        {
+            _impl.Update();
+        }
+
+    uint8_t* getPixels() const
+        {
+            return _impl.getPixels();
+        };
+
+    size_t getPixelsSize() const
+        {
+            return _impl.getPixelsSize();
+        };
+
+ private:
+    NeoEspRmtMethodImpl _impl;
+};
+
+
+// typedef NeoEspRmtMethodBase<NeoEspRmtSpeed400Kbps> NeoEsp32Rmt400KbpsMethod;
+// typedef NeoEspRmtMethodBase<detail::LED_WS2812_V1> NeoEsp32RmtWS2812_V1Method;
+// typedef NeoEspRmtMethodBase<detail::LED_WS2812B_V1> NeoEsp32RmtWS2812B_V1Method;
+// typedef NeoEspRmtMethodBase<detail::LED_WS2812B_V2> NeoEsp32RmtWS2812B_V2Method;
+// typedef NeoEspRmtMethodBase<detail::LED_WS2812B_V3> NeoEsp32RmtWS2812B_V3Method;
+// typedef NeoEspRmtMethodBase<detail::LED_WS2813_V1> NeoEsp32RmtWS2813_V1Method;
+// typedef NeoEspRmtMethodBase<detail::LED_WS2813_V2> NeoEsp32RmtWS2813_V2Method;
+typedef NeoEspRmtMethodBase<detail::LED_WS2813_V3> NeoEsp32RmtWS2813_V3Method;
+// typedef NeoEspRmtMethodBase<detail::LED_SK6812_V1> NeoEsp32RmtSK6812_V1Method;
+// typedef NeoEspRmtMethodBase<detail::LED_SK6812W_V1> NeoEsp32RmtSK6812W_V1Method;
+
+// // Bitbang method is the default method for Esp32
+// typedef NeoEsp32RmtWs2813Method NeoWs2813Method;
+// typedef NeoEsp32Rmt800KbpsMethod Neo800KbpsMethod;
+// typedef NeoEsp32Rmt400KbpsMethod Neo400KbpsMethod;
+
+#endif

--- a/src/internal/NeoPixelRmtMethod.cpp
+++ b/src/internal/NeoPixelRmtMethod.cpp
@@ -1,0 +1,113 @@
+#include <Arduino.h>
+#include "NeoEspRmtMethod.h"
+
+#include <driver/rmt.h>
+#include <driver/gpio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdexcept>
+
+std::set<rmt_channel_t> NeoEspRmtMethodImpl::s_channels = std::set<rmt_channel_t>();
+
+// /**
+//  * Set two levels of RMT output to the Neopixel value for a "1".
+//  * This is:
+//  * a logic 1 for 0.35us
+//  * a logic 0 for 0.8us
+//  */
+
+static void setItem1(rmt_item32_t *pItem, const detail::ledParams_t ledParams)
+{
+    assert(pItem != nullptr);
+    pItem->level0    = 1;
+    pItem->duration0 = 10;
+//     pItem->duration0 = ledParams.T1H / (RMT_DURATION_NS * DIVIDER);
+    pItem->level1    = 0;
+    pItem->duration1 = 6;
+//     pItem->duration1 = ledParams.T1L / (RMT_DURATION_NS * DIVIDER);
+} // setItem1
+
+/**
+ * Set two levels of RMT output to the Neopixel value for a "0".
+ * This is:
+ * a logic 1 for 0.35us
+ * a logic 0 for 0.8us
+ */
+static void setItem0(rmt_item32_t *pItem, const detail::ledParams_t ledParams)
+{
+    assert(pItem != nullptr);
+    pItem->level0    = 1;
+    pItem->duration0 = 4;
+//     pItem->duration0 = ledParams.T0H / (RMT_DURATION_NS * DIVIDER);
+    pItem->level1    = 0;
+    pItem->duration1 = 8;
+//     pItem->duration1 = ledParams.T0L / (RMT_DURATION_NS * DIVIDER);
+} // setItem0
+
+/**
+ * Add an RMT terminator into the RMT data.
+ */
+static void setTerminator(rmt_item32_t *pItem, const detail::ledParams_t ledParams)
+{
+    assert(pItem != nullptr);
+    pItem->level0    = 0;
+    pItem->duration0 = 0;
+    pItem->level1    = 0;
+    pItem->duration1 = 0;
+} // setTerminator
+
+void NeoEspRmtMethodImpl::Initialize()
+{
+    this->_items      = new rmt_item32_t[_sizePixels * 8 + 1];
+
+    rmt_config_t config;
+    config.rmt_mode                  = RMT_MODE_TX;
+    config.channel                   = this->_rmtChannel;
+    config.gpio_num                  = static_cast<gpio_num_t>(_gpioNum);
+    config.mem_block_num             = 8-this->_rmtChannel;
+    config.clk_div                   = 8;
+    config.tx_config.loop_en         = 0;
+    config.tx_config.carrier_en      = 0;
+    config.tx_config.idle_output_en  = 1;
+    config.tx_config.idle_level      = (rmt_idle_level_t)0;
+    config.tx_config.carrier_freq_hz = 10000;
+    config.tx_config.carrier_level   = (rmt_carrier_level_t)1;
+    config.tx_config.carrier_duty_percent = 50;
+
+    Serial.println("rmt_config");
+    ESP_ERROR_CHECK(rmt_config(&config));
+    Serial.println("rmt_driver_install");
+    ESP_ERROR_CHECK(rmt_driver_install(this->_rmtChannel, 0, 0));
+
+}
+
+void NeoEspRmtMethodImpl::Update()
+{
+    auto pCurrentItem = this->_items;
+    auto ledParams = detail::ledParamsAll[this->_ledType];
+
+    for (auto i = 0; i < this->_sizePixels; ++i)
+    {
+        uint8_t currentPixel = this->_pixels[i];
+
+
+        for (int j = 7; j >= 0; --j)
+        {
+            // We have 8 bits of data representing the red, green amd blue channels. The value of the
+            // 8 bits to output is in the variable current_pixel.  We now need to stream this value
+            // through RMT in most significant bit first.  To do this, we iterate through each of the 8
+            // bits from MSB to LSB.
+            if (currentPixel & (1<<j)) {
+                setItem1(pCurrentItem, ledParams);
+            } else {
+                setItem0(pCurrentItem, ledParams);
+            }
+            pCurrentItem++;
+        }
+    }
+    setTerminator(pCurrentItem, ledParams); // Write the RMT terminator.
+
+    // Show the pixels.
+    ESP_ERROR_CHECK(rmt_write_items(this->_rmtChannel, this->_items, this->_sizePixels * 8, 1 /* wait till done */));
+}

--- a/src/internal/NeoPixelRmtMethod.cpp
+++ b/src/internal/NeoPixelRmtMethod.cpp
@@ -1,6 +1,8 @@
 #include <Arduino.h>
 #include "NeoEspRmtMethod.h"
 
+#if defined(ARDUINO_ARCH_ESP32)
+
 #include <driver/rmt.h>
 #include <driver/gpio.h>
 #include <stdint.h>
@@ -109,3 +111,5 @@ void NeoEspRmtMethodImpl::Update()
     // Show the pixels.
     ESP_ERROR_CHECK(rmt_write_items(this->_rmtChannel, this->_items, this->_sizePixels * 8, 1 /* wait till done */));
 }
+
+#endif // defined(ARDUINO_ARCH_ESP32)

--- a/src/internal/NeoPixelRmtMethod.cpp
+++ b/src/internal/NeoPixelRmtMethod.cpp
@@ -75,9 +75,7 @@ void NeoEspRmtMethodImpl::Initialize()
     config.tx_config.carrier_level   = (rmt_carrier_level_t)1;
     config.tx_config.carrier_duty_percent = 50;
 
-    Serial.println("rmt_config");
     ESP_ERROR_CHECK(rmt_config(&config));
-    Serial.println("rmt_driver_install");
     ESP_ERROR_CHECK(rmt_driver_install(this->_rmtChannel, 0, 0));
 
 }


### PR DESCRIPTION
The busy wait and disable interrupt method did not work out for me, I always had incorrect pixels in my strip. After I found the RMT approach to the pixel strips, I decided to use the work of Neil Kolban (https://github.com/nkolban/esp32-snippets/blob/master/cpp_utils/WS2812.cpp) and make it available in NeoPixelBus. Thanks Neil for it!

This is far from perfect:
* I do not understand the timings in the source. From https://github.com/MartyMacGyver/ESP32-Digital-RGB-LED-Drivers/blob/master/arduino-esp32/demo1/esp32_digital_led_lib.h I tried to support the different timings of the LED types, but using the original timings and a divider gave no result. So I simply took the timings from the original without knowing why they are not symmetric.
* I don't know, but IMHO this approach should be the default on ESP32.

Comments and changes welcome.
Cheers Sven