### PR TITLE
Allow esp32 I2S to compile on case-sensitive filesystems

### DIFF
--- a/src/internal/Esp32_i2s.c
+++ b/src/internal/Esp32_i2s.c
@@ -38,7 +38,7 @@
 #include "driver/gpio.h"
 #include "driver/i2s.h"
 #include "driver/dac.h"
-#include "esp32_i2s.h"
+#include "Esp32_i2s.h"
 #include "esp32-hal.h"
 
 #define I2S_BASE_CLK (160000000L)


### PR DESCRIPTION
Header is uppercase but was included as lowercase :)

Thanks