### PR TITLE
Esp32 spi Fixes

### DIFF
--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -137,6 +137,13 @@ public:
         Dirty();
     }
 
+    // used by DotStartSpiMethod if pins can be configured
+    void Begin(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    {
+        _method.Initialize(sck, miso, mosi, ss);
+        Dirty();
+    }
+
     void Show()
     {
         if (!IsDirty())

--- a/src/internal/DotStarSpiMethod.h
+++ b/src/internal/DotStarSpiMethod.h
@@ -51,11 +51,13 @@ public:
         return true; // dot stars don't have a required delay
     }
 
+#if defined(ARDUINO_ARCH_ESP32)
     void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     {
         SPI.begin(sck, miso, mosi, ss);
         init();
     }
+#endif
 
     void Initialize()
     {
@@ -92,8 +94,10 @@ private:
 
     void init()
     {
-#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
-        SPI.setFrequency(20000000L);
+#if defined(ARDUINO_ARCH_ESP8266) 
+        SPI.setFrequency(4000000L); // more than 4mhz causes CLK pulse malformation
+#elif defined(ARDUINO_ARCH_ESP32)
+        SPI.setFrequency(4000000L); // more than 4mhz causes CLK pulse malformation
 #elif defined(ARDUINO_ARCH_AVR) 
         SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
 #else

--- a/src/internal/DotStarSpiMethod.h
+++ b/src/internal/DotStarSpiMethod.h
@@ -51,19 +51,16 @@ public:
         return true; // dot stars don't have a required delay
     }
 
+    void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    {
+        SPI.begin(sck, miso, mosi, ss);
+        init();
+    }
+
     void Initialize()
     {
         SPI.begin();
-
-#if defined(ARDUINO_ARCH_ESP8266)
-        SPI.setFrequency(20000000L);
-#elif defined(ARDUINO_ARCH_AVR) 
-        SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
-#else
-        SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
-#endif
-        SPI.setBitOrder(MSBFIRST);
-        SPI.setDataMode(SPI_MODE0);
+        init();
     }
 
     void Update()
@@ -92,6 +89,19 @@ private:
     const size_t   _sizeSendBuffer;   // Size of '_sendBuffer' buffer below
 
     uint8_t* _sendBuffer;       // Holds SPI send Buffer, including LED color values
+
+    void init()
+    {
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+        SPI.setFrequency(20000000L);
+#elif defined(ARDUINO_ARCH_AVR) 
+        SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
+#else
+        SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
+#endif
+        SPI.setBitOrder(MSBFIRST);
+        SPI.setDataMode(SPI_MODE0);
+    }
 
     size_t calcBufferSize(size_t sizePixels) const
     {


### PR DESCRIPTION
Exposes the ability to set the pins for SPI hardware on Esp32
Fixes SPI hardware support frequency for both Esp32 and Esp8266