### PR TITLE
Fix "discards qualifiers" compiler error

### DIFF
--- a/src/internal/NeoEsp8266DmaMethod.h
+++ b/src/internal/NeoEsp8266DmaMethod.h
@@ -168,7 +168,7 @@ public:
         free(_i2sBufDesc);
     }
 
-    bool IsReadyToUpdate() 
+    bool IsReadyToUpdate() const
     {
         return (_dmaState == NeoDmaState_Idle);
     }


### PR DESCRIPTION
GCC wouldn't compile because NeoPixelBus::CanShow() is declared const but IsReadyToUpdate() is not:

    NeoPixelBus.h:161:40: error: passing 'const NeoEsp8266DmaMethodBase<NeoEsp8266DmaSpeedWs2812x>' as 'this' argument of 'bool NeoEsp8266DmaMethodBase<T_SPEED>::IsReadyToUpdate() [with T_SPEED = NeoEsp8266DmaSpeedWs2812x]' discards qualifiers [-fpermissive]`

Making IsReadyToUpdate() const solves the issue.