### PR TITLE
Added remaining missing DotStar Features for color orders

### DIFF
--- a/src/internal/DotStarColorFeatures.h
+++ b/src/internal/DotStarColorFeatures.h
@@ -324,3 +324,85 @@ public:
 
 };
 
+/* RGB Feature -- Some APA102s ship in RGB order */
+class DotStarRgbFeature : public DotStar3Elements
+{
+public:
+    static void applyPixelColor(uint8_t* pPixels, uint16_t indexPixel, ColorObject color)
+    {
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        *p++ = 0xff; // upper three bits are always 111 and brightness at max
+        *p++ = color.R;
+        *p++ = color.G;
+        *p = color.B;
+    }
+
+    static ColorObject retrievePixelColor(uint8_t* pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        p++; // ignore the first byte
+        color.R = *p++;
+        color.G = *p++;
+        color.B = *p;
+
+        return color;
+    }
+
+    static ColorObject retrievePixelColor_P(PGM_VOID_P pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        const uint8_t* p = getPixelAddress((const uint8_t*)pPixels, indexPixel);
+
+        pgm_read_byte(p++); // ignore the first byte
+        color.R = pgm_read_byte(p++);
+        color.G = pgm_read_byte(p++);
+        color.B = pgm_read_byte(p);
+
+        return color;
+    }
+
+};
+
+class DotStarLrgbFeature : public DotStar4Elements
+{
+public:
+    static void applyPixelColor(uint8_t* pPixels, uint16_t indexPixel, ColorObject color)
+    {
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        *p++ = 0xE0 | (color.W < 31 ? color.W : 31); // upper three bits are always 111
+        *p++ = color.R;
+        *p++ = color.G;
+        *p = color.B;
+    }
+
+    static ColorObject retrievePixelColor(uint8_t* pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        color.W = (*p++) & 0x1F; // mask out upper three bits
+        color.R = *p++;
+        color.G = *p++;
+        color.B = *p;
+
+        return color;
+    }
+
+    static ColorObject retrievePixelColor_P(PGM_VOID_P pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        const uint8_t* p = getPixelAddress((const uint8_t*)pPixels, indexPixel);
+
+        color.W = pgm_read_byte(p++) & 0x1F; // mask out upper three bits
+        color.R = pgm_read_byte(p++);
+        color.G = pgm_read_byte(p++);
+        color.B = pgm_read_byte(p);
+
+        return color;
+    }
+
+};

--- a/src/internal/DotStarColorFeatures.h
+++ b/src/internal/DotStarColorFeatures.h
@@ -488,3 +488,168 @@ public:
     }
 
 };
+
+/* GBR Feature -- Some APA102s ship in GBR order */
+class DotStarGbrFeature : public DotStar3Elements
+{
+public:
+    static void applyPixelColor(uint8_t* pPixels, uint16_t indexPixel, ColorObject color)
+    {
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        *p++ = 0xff; // upper three bits are always 111 and brightness at max
+        *p++ = color.G;
+        *p++ = color.B;
+        *p = color.R;
+    }
+
+    static ColorObject retrievePixelColor(uint8_t* pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        p++; // ignore the first byte
+        color.G = *p++;
+        color.B = *p++;
+        color.R = *p;
+
+        return color;
+    }
+
+    static ColorObject retrievePixelColor_P(PGM_VOID_P pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        const uint8_t* p = getPixelAddress((const uint8_t*)pPixels, indexPixel);
+
+        pgm_read_byte(p++); // ignore the first byte
+        color.G = pgm_read_byte(p++);
+        color.B = pgm_read_byte(p++);
+        color.R = pgm_read_byte(p);
+
+        return color;
+    }
+
+};
+
+class DotStarLrgbFeature : public DotStar4Elements
+{
+public:
+    static void applyPixelColor(uint8_t* pPixels, uint16_t indexPixel, ColorObject color)
+    {
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        *p++ = 0xE0 | (color.W < 31 ? color.W : 31); // upper three bits are always 111
+        *p++ = color.G;
+        *p++ = color.B;
+        *p = color.R;
+    }
+
+    static ColorObject retrievePixelColor(uint8_t* pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        color.W = (*p++) & 0x1F; // mask out upper three bits
+        color.G = *p++;
+        color.B = *p++;
+        color.R = *p;
+
+        return color;
+    }
+
+    static ColorObject retrievePixelColor_P(PGM_VOID_P pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        const uint8_t* p = getPixelAddress((const uint8_t*)pPixels, indexPixel);
+
+        color.W = pgm_read_byte(p++) & 0x1F; // mask out upper three bits
+        color.G = pgm_read_byte(p++);
+        color.B = pgm_read_byte(p++);
+        color.R = pgm_read_byte(p);
+
+        return color;
+    }
+
+};
+/* BRG Feature -- Some APA102s ship in BRG order */
+class DotStarBrgFeature : public DotStar3Elements
+{
+public:
+    static void applyPixelColor(uint8_t* pPixels, uint16_t indexPixel, ColorObject color)
+    {
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        *p++ = 0xff; // upper three bits are always 111 and brightness at max
+        *p++ = color.B;
+        *p++ = color.R;
+        *p = color.G;
+    }
+
+    static ColorObject retrievePixelColor(uint8_t* pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        p++; // ignore the first byte
+        color.B = *p++;
+        color.R = *p++;
+        color.G = *p;
+
+        return color;
+    }
+
+    static ColorObject retrievePixelColor_P(PGM_VOID_P pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        const uint8_t* p = getPixelAddress((const uint8_t*)pPixels, indexPixel);
+
+        pgm_read_byte(p++); // ignore the first byte
+        color.B = pgm_read_byte(p++);
+        color.R = pgm_read_byte(p++);
+        color.G = pgm_read_byte(p);
+
+        return color;
+    }
+
+};
+
+class DotStarLrgbFeature : public DotStar4Elements
+{
+public:
+    static void applyPixelColor(uint8_t* pPixels, uint16_t indexPixel, ColorObject color)
+    {
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        *p++ = 0xE0 | (color.W < 31 ? color.W : 31); // upper three bits are always 111
+        *p++ = color.B;
+        *p++ = color.R;
+        *p = color.G;
+    }
+
+    static ColorObject retrievePixelColor(uint8_t* pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        color.W = (*p++) & 0x1F; // mask out upper three bits
+        color.B = *p++;
+        color.R = *p++;
+        color.G = *p;
+
+        return color;
+    }
+
+    static ColorObject retrievePixelColor_P(PGM_VOID_P pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        const uint8_t* p = getPixelAddress((const uint8_t*)pPixels, indexPixel);
+
+        color.W = pgm_read_byte(p++) & 0x1F; // mask out upper three bits
+        color.B = pgm_read_byte(p++);
+        color.R = pgm_read_byte(p++);
+        color.G = pgm_read_byte(p);
+
+        return color;
+    }
+
+};

--- a/src/internal/DotStarColorFeatures.h
+++ b/src/internal/DotStarColorFeatures.h
@@ -406,3 +406,85 @@ public:
     }
 
 };
+/* RBG Feature -- Some APA102s ship in RBG order */
+class DotStarRbgFeature : public DotStar3Elements
+{
+public:
+    static void applyPixelColor(uint8_t* pPixels, uint16_t indexPixel, ColorObject color)
+    {
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        *p++ = 0xff; // upper three bits are always 111 and brightness at max
+        *p++ = color.R;
+        *p++ = color.B;
+        *p = color.G;
+    }
+
+    static ColorObject retrievePixelColor(uint8_t* pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        p++; // ignore the first byte
+        color.R = *p++;
+        color.B = *p++;
+        color.G = *p;
+
+        return color;
+    }
+
+    static ColorObject retrievePixelColor_P(PGM_VOID_P pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        const uint8_t* p = getPixelAddress((const uint8_t*)pPixels, indexPixel);
+
+        pgm_read_byte(p++); // ignore the first byte
+        color.R = pgm_read_byte(p++);
+        color.B = pgm_read_byte(p++);
+        color.G = pgm_read_byte(p);
+
+        return color;
+    }
+
+};
+
+class DotStarLrgbFeature : public DotStar4Elements
+{
+public:
+    static void applyPixelColor(uint8_t* pPixels, uint16_t indexPixel, ColorObject color)
+    {
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        *p++ = 0xE0 | (color.W < 31 ? color.W : 31); // upper three bits are always 111
+        *p++ = color.R;
+        *p++ = color.B;
+        *p = color.G;
+    }
+
+    static ColorObject retrievePixelColor(uint8_t* pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        uint8_t* p = getPixelAddress(pPixels, indexPixel);
+
+        color.W = (*p++) & 0x1F; // mask out upper three bits
+        color.R = *p++;
+        color.B = *p++;
+        color.G = *p;
+
+        return color;
+    }
+
+    static ColorObject retrievePixelColor_P(PGM_VOID_P pPixels, uint16_t indexPixel)
+    {
+        ColorObject color;
+        const uint8_t* p = getPixelAddress((const uint8_t*)pPixels, indexPixel);
+
+        color.W = pgm_read_byte(p++) & 0x1F; // mask out upper three bits
+        color.R = pgm_read_byte(p++);
+        color.B = pgm_read_byte(p++);
+        color.G = pgm_read_byte(p);
+
+        return color;
+    }
+
+};


### PR DESCRIPTION
It occurred to me that there are very few missing permutations of RGB left, so I expanded them all and completed the missing ones.
