### PR TITLE
Fix 32bit pointer cast lint error

### DIFF
--- a/src/internal/NeoEsp8266DmaMethod.h
+++ b/src/internal/NeoEsp8266DmaMethod.h
@@ -195,7 +195,12 @@ public:
             _i2sBufDesc[indexDesc].sub_sof = 0;
             _i2sBufDesc[indexDesc].datalen = blockSize;
             _i2sBufDesc[indexDesc].blocksize = blockSize;
-            _i2sBufDesc[indexDesc].buf_ptr = (uint32_t)is2Buffer;
+            union {
+                uint8_t *ptr;
+                uint32_t value;
+            } ptr;
+            ptr.ptr = is2Buffer;
+            _i2sBufDesc[indexDesc].buf_ptr = ptr.value;
             _i2sBufDesc[indexDesc].unused = 0;
             _i2sBufDesc[indexDesc].next_link_ptr = (uint32_t)&(_i2sBufDesc[indexDesc + 1]);
 
@@ -361,12 +366,15 @@ private:
 
             case NeoDmaState_Sending:
                 {
-                    slc_queue_item* finished_item = (slc_queue_item*)SLCRXEDA;
-
+                    union {
+                        slc_queue_item *ptr;
+                        uint32_t value;
+                    } ptr;
+                    ptr.value = SLCRXEDA;
                     // the data block had actual data sent
                     // point last state block to first state block thus
                     // just looping and not sending the data blocks
-                    (finished_item + 1)->next_link_ptr = (uint32_t)(finished_item);
+                    (ptr.ptr + 1)->next_link_ptr = ptr.value;
 
                     s_this->_dmaState = NeoDmaState_Zeroing;
                 }


### PR DESCRIPTION
Hi, I use neopixelbus in my project as a dependency, and my project is statically lint-checked with clang-tidy.

However, clang-tidy freaks out over these pointer to uint32_t casts (technically against C++ standard I think, haven't looked at the exact wording for that though) - and because it's an compile error not a warning it can't be marked as an ignored error. 

So until now I used to manually patch the lib to work around it (https://github.com/esphome/esphome/blob/dev/script/.neopixelbus.patch)

This PR uses unions to do the same thing and keeps linters from generating errors.

Haven't looked at the generated binary - but I'd assume this is equivalent to the previous code.