### PR TITLE
Compiles for Esp32S2 

### DIFF
--- a/src/internal/NeoEp32RmtMethod.cpp
+++ b/src/internal/NeoEp32RmtMethod.cpp
@@ -1,0 +1,192 @@
+/*-------------------------------------------------------------------------
+NeoPixel library helper functions for Esp32.
+
+A BIG thanks to Andreas Merkle for the investigation and implementation of
+a workaround to the GCC bug that drops method attributes from template methods
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/NeoPixelBus)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/NeoPixelBus library.
+
+NeoPixelBus is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+NeoPixelBus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with NeoPixel.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+#include "NeoEsp32RmtMethod.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+
+
+// these are required due to the linker error with ISRs
+// dangerous relocation: l32r: literal placed after use
+// https://stackoverflow.com/questions/19532826/what-does-a-dangerous-relocation-error-mean
+//
+void NeoEsp32RmtSpeedWs2811::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtSpeedWs2812x::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtSpeedSk6812::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtSpeedTm1814::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtSpeed800Kbps::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtSpeed400Kbps::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtSpeedApa106::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtInvertedSpeedWs2811::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtInvertedSpeedWs2812x::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtInvertedSpeedSk6812::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtInvertedSpeedTm1814::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtInvertedSpeed800Kbps::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtInvertedSpeed400Kbps::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+void NeoEsp32RmtInvertedSpeedApa106::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+#endif

--- a/src/internal/NeoEsp32RmtMethod.h
+++ b/src/internal/NeoEsp32RmtMethod.h
@@ -1,6 +1,9 @@
 /*-------------------------------------------------------------------------
 NeoPixel library helper functions for Esp32.
 
+A BIG thanks to Andreas Merkle for the investigation and implementation of
+a workaround to the GCC bug that drops method attributes from template methods 
+
 Written by Michael C. Miller.
 
 I invest time and resources providing this open source code,
@@ -40,9 +43,10 @@ Esp32-hal-rmt.h
 Esp32-hal-rmt.c
 */
 
+#include <Arduino.h>
+
 extern "C"
 {
-#include <Arduino.h>
 #include <driver/rmt.h>
 }
 
@@ -65,6 +69,71 @@ protected:
     const static uint32_t NsPerSecond = 1000000000L;
     const static uint32_t RmtTicksPerSecond = (RmtCpu / RmtClockDivider);
     const static uint32_t NsPerRmtTick = (NsPerSecond / RmtTicksPerSecond); // about 25 
+
+    // translate NeoPixelBuffer into RMT buffer
+    // this is done on the fly so we don't require a send buffer in raw RMT format
+    // which would be 32x larger than the primary buffer
+    // NOTE:  This was moved from the template below to here to workaround a GCC bug
+    //  That bug is that the IRAM_ATTR attribute (any attributes) is lost on template classes.  
+    //
+    static void IRAM_ATTR _translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num,
+        const uint32_t rmtBit0,
+        const uint32_t rmtBit1,
+        const uint16_t rmtDurationReset)
+    {
+        if (src == NULL || dest == NULL)
+        {
+            *translated_size = 0;
+            *item_num = 0;
+            return;
+        }
+
+        size_t size = 0;
+        size_t num = 0;
+        const uint8_t* psrc = static_cast<const uint8_t*>(src);
+        rmt_item32_t* pdest = dest;
+
+        for (;;)
+        {
+            uint8_t data = *psrc;
+
+            for (uint8_t bit = 0; bit < 8; bit++)
+            {
+                pdest->val = (data & 0x80) ? rmtBit1 : rmtBit0;
+                pdest++;
+                data <<= 1;
+            }
+            num += 8;
+            size++;
+
+            // if this is the last byte we need to adjust the length of the last pulse
+            if (size >= src_size)
+            {
+                // extend the last bits LOW value to include the full reset signal length
+                pdest--;
+                pdest->duration1 = rmtDurationReset;
+                // and stop updating data to send
+                break;
+            }
+
+            if (num >= wanted_num)
+            {
+                // stop updating data to send
+                break;
+            }
+
+            psrc++;
+        }
+
+        *translated_size = size;
+        *item_num = num;
+    }
+
 };
 
 class NeoEsp32RmtSpeedBase : public NeoEsp32RmtSpeed
@@ -99,6 +168,13 @@ public:
     const static uint32_t RmtBit0 = Item32Val(300, 950); 
     const static uint32_t RmtBit1 = Item32Val(900, 350); 
     const static uint16_t RmtDurationReset = FromNs(300000); // 300us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtSpeedWs2812x : public NeoEsp32RmtSpeedBase
@@ -107,6 +183,13 @@ public:
 	const static uint32_t RmtBit0 = Item32Val(400, 850);
 	const static uint32_t RmtBit1 = Item32Val(800, 450);
 	const static uint16_t RmtDurationReset = FromNs(300000); // 300us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtSpeedSk6812 : public NeoEsp32RmtSpeedBase
@@ -115,6 +198,13 @@ public:
     const static uint32_t RmtBit0 = Item32Val(400, 850); 
     const static uint32_t RmtBit1 = Item32Val(800, 450); 
     const static uint16_t RmtDurationReset = FromNs(80000); // 80us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 // normal is inverted signal
@@ -124,6 +214,13 @@ public:
     const static uint32_t RmtBit0 = Item32Val(360, 890);
     const static uint32_t RmtBit1 = Item32Val(720, 530);
     const static uint16_t RmtDurationReset = FromNs(200000); // 200us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtSpeed800Kbps : public NeoEsp32RmtSpeedBase
@@ -132,6 +229,13 @@ public:
     const static uint32_t RmtBit0 = Item32Val(400, 850); 
     const static uint32_t RmtBit1 = Item32Val(800, 450); 
     const static uint16_t RmtDurationReset = FromNs(50000); // 50us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtSpeed400Kbps : public NeoEsp32RmtSpeedBase
@@ -140,6 +244,13 @@ public:
     const static uint32_t RmtBit0 = Item32Val(800, 1700); 
     const static uint32_t RmtBit1 = Item32Val(1600, 900); 
     const static uint16_t RmtDurationReset = FromNs(50000); // 50us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtSpeedApa106 : public NeoEsp32RmtSpeedBase
@@ -148,6 +259,13 @@ public:
 	const static uint32_t RmtBit0 = Item32Val(400, 1250);
 	const static uint32_t RmtBit1 = Item32Val(1250, 400);
 	const static uint16_t RmtDurationReset = FromNs(50000); // 50us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtInvertedSpeedWs2811 : public NeoEsp32RmtInvertedSpeedBase
@@ -156,6 +274,13 @@ public:
 	const static uint32_t RmtBit0 = Item32Val(300, 950);
 	const static uint32_t RmtBit1 = Item32Val(900, 350);
 	const static uint16_t RmtDurationReset = FromNs(300000); // 300us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtInvertedSpeedWs2812x : public NeoEsp32RmtInvertedSpeedBase
@@ -164,6 +289,13 @@ public:
 	const static uint32_t RmtBit0 = Item32Val(400, 850);
 	const static uint32_t RmtBit1 = Item32Val(800, 450);
 	const static uint16_t RmtDurationReset = FromNs(300000); // 300us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtInvertedSpeedSk6812 : public NeoEsp32RmtInvertedSpeedBase
@@ -172,6 +304,13 @@ public:
 	const static uint32_t RmtBit0 = Item32Val(400, 850);
 	const static uint32_t RmtBit1 = Item32Val(800, 450);
 	const static uint16_t RmtDurationReset = FromNs(80000); // 80us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 // normal is inverted signal
@@ -181,6 +320,13 @@ public:
     const static uint32_t RmtBit0 = Item32Val(360, 890);
     const static uint32_t RmtBit1 = Item32Val(720, 530);
     const static uint16_t RmtDurationReset = FromNs(200000); // 200us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtInvertedSpeed800Kbps : public NeoEsp32RmtInvertedSpeedBase
@@ -189,6 +335,13 @@ public:
 	const static uint32_t RmtBit0 = Item32Val(400, 850);
 	const static uint32_t RmtBit1 = Item32Val(800, 450);
 	const static uint16_t RmtDurationReset = FromNs(50000); // 50us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtInvertedSpeed400Kbps : public NeoEsp32RmtInvertedSpeedBase
@@ -197,6 +350,13 @@ public:
 	const static uint32_t RmtBit0 = Item32Val(800, 1700);
 	const static uint32_t RmtBit1 = Item32Val(1600, 900);
 	const static uint16_t RmtDurationReset = FromNs(50000); // 50us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtInvertedSpeedApa106 : public NeoEsp32RmtInvertedSpeedBase
@@ -205,6 +365,13 @@ public:
 	const static uint32_t RmtBit0 = Item32Val(400, 1250);
 	const static uint32_t RmtBit1 = Item32Val(1250, 400);
 	const static uint16_t RmtDurationReset = FromNs(50000); // 50us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
 };
 
 class NeoEsp32RmtChannel0
@@ -310,8 +477,8 @@ public:
         config.clk_div = T_SPEED::RmtClockDivider;
 
         ESP_ERROR_CHECK(rmt_config(&config));
-        ESP_ERROR_CHECK(rmt_driver_install(T_CHANNEL::RmtChannelNumber, 0, 0));
-        ESP_ERROR_CHECK(rmt_translator_init(T_CHANNEL::RmtChannelNumber, _translate));
+        ESP_ERROR_CHECK(rmt_driver_install(T_CHANNEL::RmtChannelNumber, 0, ESP_INTR_FLAG_IRAM));
+        ESP_ERROR_CHECK(rmt_translator_init(T_CHANNEL::RmtChannelNumber, T_SPEED::Translate));
     }
 
     void Update(bool maintainBufferConsistency)
@@ -354,65 +521,6 @@ private:
     // Holds data stream which include LED color values and other settings as needed
     uint8_t*  _dataEditing;   // exposed for get and set
     uint8_t*  _dataSending;   // used for async send using RMT
-
-
-    // stranslate NeoPixelBuffer into RMT buffer
-    // this is done on the fly so we don't require a send buffer in raw RMT format
-    // which would be 32x larger than the primary buffer
-    static void IRAM_ATTR _translate(const void* src,
-        rmt_item32_t* dest,
-        size_t src_size,
-        size_t wanted_num,
-        size_t* translated_size,
-        size_t* item_num)
-    {
-        if (src == NULL || dest == NULL) 
-        {
-            *translated_size = 0;
-            *item_num = 0;
-            return;
-        }
-
-        size_t size = 0;
-        size_t num = 0;
-        const uint8_t* psrc = static_cast<const uint8_t*>(src);
-        rmt_item32_t* pdest = dest;
-
-        for (;;)
-        {
-            uint8_t data = *psrc;
-
-            for (uint8_t bit = 0; bit < 8; bit++)
-            {
-                pdest->val = (data & 0x80) ? T_SPEED::RmtBit1 : T_SPEED::RmtBit0;
-                pdest++;
-                data <<= 1;
-            }
-            num += 8;
-            size++;
-
-            // if this is the last byte we need to adjust the length of the last pulse
-            if (size >= src_size)
-            {
-                // extend the last bits LOW value to include the full reset signal length
-                pdest--;
-                pdest->duration1 = T_SPEED::RmtDurationReset;
-                // and stop updating data to send
-                break; 
-            }
-
-            if (num >= wanted_num)
-            {
-                // stop updating data to send
-                break;
-            }
-
-            psrc++;
-        }
-
-        *translated_size = size;
-        *item_num = num;
-    }
 };
 
 // normal


### PR DESCRIPTION
Workaround for IRAM attribute lost on template methods.
This approach removes the extra call in the translate ISR but only compiles with the github master of esp32 Arduino.