### PR TITLE
Fixed uninitialized member

### DIFF
--- a/src/internal/NeoEspBitBangMethod.h
+++ b/src/internal/NeoEspBitBangMethod.h
@@ -261,7 +261,8 @@ template<typename T_SPEED, typename T_PINSET> class NeoEspBitBangMethodBase
 public:
     NeoEspBitBangMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
         _sizeData(pixelCount * elementSize + settingsSize),
-        _pin(pin)
+        _pin(pin),
+        _endTime(0)
     {
         pinMode(pin, OUTPUT);
 

--- a/src/internal/Ws2801GenericMethod.h
+++ b/src/internal/Ws2801GenericMethod.h
@@ -39,6 +39,7 @@ template<typename T_TWOWIRE> class Ws2801MethodBase
 public:
     Ws2801MethodBase(uint8_t pinClock, uint8_t pinData, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
         _sizeData(pixelCount * elementSize + settingsSize),
+        _endTime(0),
         _wire(pinClock, pinData)
     {
         _data = static_cast<uint8_t*>(malloc(_sizeData));


### PR DESCRIPTION
See cppcheck warnings:
src/internal/Ws2801GenericMethod.h:40: [medium:warning] Member variable 'Ws2801MethodBase::_endTime' is not initialized in the constructor. [uninitMemberVar]
src/internal/Ws2801GenericMethod.h:49: [medium:warning] Member variable 'Ws2801MethodBase::_endTime' is not initialized in the constructor. [uninitMemberVar]
src/internal/NeoEspBitBangMethod.h:262: [medium:warning] Member variable 'NeoEspBitBangMethodBase::_endTime' is not initialized in the constructor.