### PR TITLE
ESP32 force bitbang in IRAM

### DIFF
--- a/src/internal/NeoEspBitBangMethod.cpp
+++ b/src/internal/NeoEspBitBangMethod.cpp
@@ -1,0 +1,115 @@
+/*-------------------------------------------------------------------------
+NeoPixel library helper functions for Esp8266 and Esp32
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/NeoPixelBus)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/NeoPixelBus library.
+
+NeoPixelBus is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+NeoPixelBus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with NeoPixel.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+
+#include <Arduino.h>
+#include "NeoEspBitBangMethod.h"
+
+static inline uint32_t getCycleCount(void)
+{
+    uint32_t ccount;
+    __asm__ __volatile__("rsr %0,ccount":"=a" (ccount));
+    return ccount;
+}
+
+void ICACHE_RAM_ATTR NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin, uint32_t t0h, uint32_t t1h, uint32_t period, uint8_t IdleLevel)
+{
+    const uint32_t pinRegister = _BV(pin);
+    uint8_t mask = 0x80;
+    uint8_t subpix = *pixels++;
+    uint32_t cyclesStart = 0; // trigger emediately
+    uint32_t cyclesNext = 0;
+
+    for (;;)
+    {
+        // do the checks here while we are waiting on time to pass
+        uint32_t cyclesBit = t0h;
+        if (subpix & mask)
+        {
+            cyclesBit = t1h;
+        }
+
+        // after we have done as much work as needed for this next bit
+        // now wait for the HIGH
+        while (((cyclesStart = getCycleCount()) - cyclesNext) < period);
+
+        // set pin state
+        if (IdleLevel == LOW) {
+#if defined(ARDUINO_ARCH_ESP32)
+            GPIO.out_w1ts = pinRegister;
+#else
+            GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
+#endif
+        } else {
+#if defined(ARDUINO_ARCH_ESP32)
+            GPIO.out_w1tc = pinRegister;
+#else
+            GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
+#endif
+        }
+        // T_PINSET::setPin(pinRegister);
+
+        // wait for the LOW
+        while ((getCycleCount() - cyclesStart) < cyclesBit);
+
+        // reset pin start
+        if (IdleLevel == LOW) {
+#if defined(ARDUINO_ARCH_ESP32)
+            GPIO.out_w1tc = pinRegister;
+#else
+            GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
+#endif
+        } else {
+#if defined(ARDUINO_ARCH_ESP32)
+            GPIO.out_w1ts = pinRegister;
+#else
+            GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
+#endif
+        }
+        // T_PINSET::resetPin(pinRegister);
+
+        cyclesNext = cyclesStart;
+
+        // next bit
+        mask >>= 1;
+        if (mask == 0)
+        {
+            // no more bits to send in this byte
+            // check for another byte
+            if (pixels >= end)
+            {
+                // no more bytes to send so stop
+                break;
+            }
+            // reset mask to first bit and get the next byte
+            mask = 0x80;
+            subpix = *pixels++;
+        }
+    }
+}
+
+#endif

--- a/src/internal/NeoEspBitBangMethod.cpp
+++ b/src/internal/NeoEspBitBangMethod.cpp
@@ -62,7 +62,6 @@ void ICACHE_RAM_ATTR NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end
 #else
         GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
 #endif
-        // T_PINSET::setPin(pinRegister);
 
         // wait for the LOW
         while ((getCycleCount() - cyclesStart) < cyclesBit);
@@ -73,7 +72,6 @@ void ICACHE_RAM_ATTR NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end
 #else
         GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
 #endif
-        // T_PINSET::resetPin(pinRegister);
 
         cyclesNext = cyclesStart;
 
@@ -122,7 +120,6 @@ void ICACHE_RAM_ATTR NeoEspBitBangBase_send_pixels_inv(uint8_t* pixels, uint8_t*
 #else
         GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
 #endif
-        // T_PINSET::setPin(pinRegister);
 
         // wait for the LOW
         while ((getCycleCount() - cyclesStart) < cyclesBit);
@@ -133,7 +130,6 @@ void ICACHE_RAM_ATTR NeoEspBitBangBase_send_pixels_inv(uint8_t* pixels, uint8_t*
 #else
         GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
 #endif
-        // T_PINSET::resetPin(pinRegister);
 
         cyclesNext = cyclesStart;
 

--- a/src/internal/NeoEspBitBangMethod.cpp
+++ b/src/internal/NeoEspBitBangMethod.cpp
@@ -27,7 +27,6 @@ License along with NeoPixel.  If not, see
 #if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
 
 #include <Arduino.h>
-#include "NeoEspBitBangMethod.h"
 
 static inline uint32_t getCycleCount(void)
 {

--- a/src/internal/NeoEspBitBangMethod.cpp
+++ b/src/internal/NeoEspBitBangMethod.cpp
@@ -36,7 +36,7 @@ static inline uint32_t getCycleCount(void)
     return ccount;
 }
 
-void ICACHE_RAM_ATTR NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin, uint32_t t0h, uint32_t t1h, uint32_t period, uint8_t IdleLevel)
+void ICACHE_RAM_ATTR NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin, uint32_t t0h, uint32_t t1h, uint32_t period)
 {
     const uint32_t pinRegister = _BV(pin);
     uint8_t mask = 0x80;
@@ -58,38 +58,82 @@ void ICACHE_RAM_ATTR NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end
         while (((cyclesStart = getCycleCount()) - cyclesNext) < period);
 
         // set pin state
-        if (IdleLevel == LOW) {
 #if defined(ARDUINO_ARCH_ESP32)
-            GPIO.out_w1ts = pinRegister;
+        GPIO.out_w1ts = pinRegister;
 #else
-            GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
+        GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
 #endif
-        } else {
-#if defined(ARDUINO_ARCH_ESP32)
-            GPIO.out_w1tc = pinRegister;
-#else
-            GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
-#endif
-        }
         // T_PINSET::setPin(pinRegister);
 
         // wait for the LOW
         while ((getCycleCount() - cyclesStart) < cyclesBit);
 
         // reset pin start
-        if (IdleLevel == LOW) {
 #if defined(ARDUINO_ARCH_ESP32)
-            GPIO.out_w1tc = pinRegister;
+        GPIO.out_w1tc = pinRegister;
 #else
-            GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
+        GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
 #endif
-        } else {
-#if defined(ARDUINO_ARCH_ESP32)
-            GPIO.out_w1ts = pinRegister;
-#else
-            GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
-#endif
+        // T_PINSET::resetPin(pinRegister);
+
+        cyclesNext = cyclesStart;
+
+        // next bit
+        mask >>= 1;
+        if (mask == 0)
+        {
+            // no more bits to send in this byte
+            // check for another byte
+            if (pixels >= end)
+            {
+                // no more bytes to send so stop
+                break;
+            }
+            // reset mask to first bit and get the next byte
+            mask = 0x80;
+            subpix = *pixels++;
         }
+    }
+}
+
+void ICACHE_RAM_ATTR NeoEspBitBangBase_send_pixels_inv(uint8_t* pixels, uint8_t* end, uint8_t pin, uint32_t t0h, uint32_t t1h, uint32_t period)
+{
+    const uint32_t pinRegister = _BV(pin);
+    uint8_t mask = 0x80;
+    uint8_t subpix = *pixels++;
+    uint32_t cyclesStart = 0; // trigger emediately
+    uint32_t cyclesNext = 0;
+
+    for (;;)
+    {
+        // do the checks here while we are waiting on time to pass
+        uint32_t cyclesBit = t0h;
+        if (subpix & mask)
+        {
+            cyclesBit = t1h;
+        }
+
+        // after we have done as much work as needed for this next bit
+        // now wait for the HIGH
+        while (((cyclesStart = getCycleCount()) - cyclesNext) < period);
+
+        // set pin state
+#if defined(ARDUINO_ARCH_ESP32)
+        GPIO.out_w1tc = pinRegister;
+#else
+        GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
+#endif
+        // T_PINSET::setPin(pinRegister);
+
+        // wait for the LOW
+        while ((getCycleCount() - cyclesStart) < cyclesBit);
+
+        // reset pin start
+#if defined(ARDUINO_ARCH_ESP32)
+        GPIO.out_w1ts = pinRegister;
+#else
+        GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
+#endif
         // T_PINSET::resetPin(pinRegister);
 
         cyclesNext = cyclesStart;

--- a/src/internal/NeoEspBitBangMethod.h
+++ b/src/internal/NeoEspBitBangMethod.h
@@ -91,109 +91,22 @@ class NeoEspPinset
 {
 public:
     const static uint8_t IdleLevel = LOW;
-
-    inline static void setPin(const uint32_t pinRegister)
-    {
-#if defined(ARDUINO_ARCH_ESP32)
-        GPIO.out_w1ts = pinRegister;
-#else
-        GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
-#endif
-    }
-
-    inline static void resetPin(const uint32_t pinRegister)
-    {
-#if defined(ARDUINO_ARCH_ESP32)
-        GPIO.out_w1tc = pinRegister;
-#else
-        GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
-#endif
-    }
 };
 
 class NeoEspPinsetInverted
 {
 public:
     const static uint8_t IdleLevel = HIGH;
-
-    inline static void setPin(const uint32_t pinRegister)
-    {
-#if defined(ARDUINO_ARCH_ESP32)
-        GPIO.out_w1tc = pinRegister;
-#else
-        GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
-#endif
-    }
-
-    inline static void resetPin(const uint32_t pinRegister)
-    {
-#if defined(ARDUINO_ARCH_ESP32)
-        GPIO.out_w1ts = pinRegister;
-#else
-        GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
-#endif
-    }
 };
+
+extern void NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin, uint32_t t0h, uint32_t t1h, uint32_t period, uint8_t IdleLevel);
 
 template<typename T_SPEED, typename T_PINSET> class NeoEspBitBangBase
 {
 public:
-    __attribute__((noinline)) static void ICACHE_RAM_ATTR send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin)
+    static void send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin)
     {
-        const uint32_t pinRegister = _BV(pin);
-        uint8_t mask = 0x80;
-        uint8_t subpix = *pixels++;
-        uint32_t cyclesStart = 0; // trigger emediately
-        uint32_t cyclesNext = 0;
-
-        for (;;)
-        {
-            // do the checks here while we are waiting on time to pass
-            uint32_t cyclesBit = T_SPEED::T0H;
-            if (subpix & mask)
-            {
-                cyclesBit = T_SPEED::T1H;
-            }
-
-            // after we have done as much work as needed for this next bit
-            // now wait for the HIGH
-            while (((cyclesStart = getCycleCount()) - cyclesNext) < T_SPEED::Period);
-
-            // set pin state
-            T_PINSET::setPin(pinRegister);
-
-            // wait for the LOW
-            while ((getCycleCount() - cyclesStart) < cyclesBit);
-
-            // reset pin start
-            T_PINSET::resetPin(pinRegister);
-
-            cyclesNext = cyclesStart;
-
-            // next bit
-            mask >>= 1;
-            if (mask == 0)
-            {
-                // no more bits to send in this byte
-                // check for another byte
-                if (pixels >= end)
-                {
-                    // no more bytes to send so stop
-                    break;
-                }
-                // reset mask to first bit and get the next byte
-                mask = 0x80;
-                subpix = *pixels++;
-            }
-        }
-    }
-
-protected:
-    static inline uint32_t getCycleCount(void)
-    {
-        uint32_t ccount;
-        __asm__ __volatile__("rsr %0,ccount":"=a" (ccount));
-        return ccount;
+        NeoEspBitBangBase_send_pixels(pixels, end, pin, T_SPEED::T0H, T_SPEED::T1H, T_SPEED::Period, T_PINSET::IdleLevel);
     }
 };
 

--- a/src/internal/NeoEspBitBangMethod.h
+++ b/src/internal/NeoEspBitBangMethod.h
@@ -87,26 +87,37 @@ public:
     const static uint32_t Period = (F_CPU / 606061 - CYCLES_LOOPTEST); // 1.65us
 };
 
+extern void NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin, uint32_t t0h, uint32_t t1h, uint32_t period);
+extern void NeoEspBitBangBase_send_pixels_inv(uint8_t* pixels, uint8_t* end, uint8_t pin, uint32_t t0h, uint32_t t1h, uint32_t period);
+
 class NeoEspPinset
 {
 public:
     const static uint8_t IdleLevel = LOW;
+
+    inline static void send_pixels_impl(uint8_t* pixels, uint8_t* end, uint8_t pin, uint32_t t0h, uint32_t t1h, uint32_t period)
+    {
+        NeoEspBitBangBase_send_pixels(pixels, end, pin, t0h, t1h, period);
+    }
 };
 
 class NeoEspPinsetInverted
 {
 public:
     const static uint8_t IdleLevel = HIGH;
-};
 
-extern void NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin, uint32_t t0h, uint32_t t1h, uint32_t period, uint8_t IdleLevel);
+    inline static void send_pixels_impl(uint8_t* pixels, uint8_t* end, uint8_t pin, uint32_t t0h, uint32_t t1h, uint32_t period)
+    {
+        NeoEspBitBangBase_send_pixels_inv(pixels, end, pin, t0h, t1h, period);
+    }
+};
 
 template<typename T_SPEED, typename T_PINSET> class NeoEspBitBangBase
 {
 public:
     static void send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin)
     {
-        NeoEspBitBangBase_send_pixels(pixels, end, pin, T_SPEED::T0H, T_SPEED::T1H, T_SPEED::Period, T_PINSET::IdleLevel);
+        T_PINSET::send_pixels_impl(pixels, end, pin, T_SPEED::T0H, T_SPEED::T1H, T_SPEED::Period);
     }
 };
 


### PR DESCRIPTION
Proposed fix to #445

I'm proposing to create a single `NeoEspBitBangBase_send_pixels()` function statically compiled with `IRAM` attribute. The templated method is just a wrapper.

Confirmed to work and forcing `NeoEspBitBangBase_send_pixels()` into IRAM.