### PR TITLE
ESP32 i2s: instead of runtime exception, silently upgrade pixelCount

### DIFF
--- a/src/internal/NeoEsp32I2sMethod.h
+++ b/src/internal/NeoEsp32I2sMethod.h
@@ -224,7 +224,11 @@ private:
 
     void construct(uint16_t pixelCount, size_t elementSize, size_t settingsSize) 
     {
-        ESP_ERROR_CHECK(pixelCount >= 2 ? ESP_OK : ESP_ERR_INVALID_ARG);
+        // DMA is too fast to support a single pixel and maintain consistency
+        if (pixelCount < 2)
+        {
+            pixelCount = 2;
+        }
 
         uint16_t dmaSettingsSize = c_dmaBytesPerPixelBytes * settingsSize;
         uint16_t dmaPixelSize = c_dmaBytesPerPixelBytes * elementSize;


### PR DESCRIPTION
Fixes #457

This workaround, compared to the old implementation of throwing an exception,
is simpler, makes the compiled program 260 smaller, and unbreaks existing code
that uses a pixel count of 1 that used to work prior to 2cce77e9 (v2.6.2).

This fix basically does the same thing as the recommended fix on the caller
side, except without bothering the caller. It does make `.GetPixelCount()`
return 2 instead of the provided number of pixels, but the resulting program is
arguably less broken than it is with the failing check at construction, and not
likely to really be much of an issue anyway.