### PR TITLE
Fix clang-tidy pointer cast error

### DIFF
--- a/src/internal/NeoEsp8266DmaMethod.h
+++ b/src/internal/NeoEsp8266DmaMethod.h
@@ -62,7 +62,7 @@ struct slc_queue_item
     uint32  eof : 1;
     uint32  owner : 1;
     uint8*  buf_ptr;
-    uint32*  next_link_ptr;
+    struct slc_queue_item*  next_link_ptr;
 };
 
 class NeoEsp8266DmaSpeedBase
@@ -316,7 +316,7 @@ public:
             _i2sBufDesc[indexDesc].blocksize = blockSize;
             _i2sBufDesc[indexDesc].buf_ptr = is2Buffer;
             _i2sBufDesc[indexDesc].unused = 0;
-            _i2sBufDesc[indexDesc].next_link_ptr = &(_i2sBufDesc[indexDesc + 1]);
+            _i2sBufDesc[indexDesc].next_link_ptr = reinterpret_cast<struct slc_queue_item*>(&(_i2sBufDesc[indexDesc + 1]));
 
             is2Buffer += blockSize;
             is2BufferSize -= blockSize;
@@ -332,13 +332,13 @@ public:
             _i2sBufDesc[indexDesc].blocksize = sizeof(_i2sZeroes);
             _i2sBufDesc[indexDesc].buf_ptr = _i2sZeroes;
             _i2sBufDesc[indexDesc].unused = 0;
-            _i2sBufDesc[indexDesc].next_link_ptr = &(_i2sBufDesc[indexDesc + 1]);
+            _i2sBufDesc[indexDesc].next_link_ptr = reinterpret_cast<struct slc_queue_item*>(&(_i2sBufDesc[indexDesc + 1]));
         }
 
         // the first state block will trigger the interrupt
         _i2sBufDesc[indexDesc - 2].eof = 1;
         // the last state block will loop to the first state block by defualt
-        _i2sBufDesc[indexDesc - 1].next_link_ptr = &(_i2sBufDesc[indexDesc - 2]);
+        _i2sBufDesc[indexDesc - 1].next_link_ptr = reinterpret_cast<struct slc_queue_item*>(&(_i2sBufDesc[indexDesc - 2]));
 
         // setup the rest of i2s DMA
         //
@@ -489,7 +489,7 @@ private:
                     // the data block had actual data sent
                     // point last state block to first state block thus
                     // just looping and not sending the data blocks
-                    (finished_item + 1)->next_link_ptr = reinterpret_cast<uint32*>(finished_item);
+                    (finished_item + 1)->next_link_ptr = finished_item;
 
                     s_this->_dmaState = NeoDmaState_Zeroing;
                 }

--- a/src/internal/NeoEsp8266DmaMethod.h
+++ b/src/internal/NeoEsp8266DmaMethod.h
@@ -61,8 +61,8 @@ struct slc_queue_item
     uint32  sub_sof : 1;
     uint32  eof : 1;
     uint32  owner : 1;
-    uint32  buf_ptr;
-    uint32  next_link_ptr;
+    uint8*  buf_ptr;
+    uint32*  next_link_ptr;
 };
 
 class NeoEsp8266DmaSpeedBase
@@ -314,9 +314,9 @@ public:
             _i2sBufDesc[indexDesc].sub_sof = 0;
             _i2sBufDesc[indexDesc].datalen = blockSize;
             _i2sBufDesc[indexDesc].blocksize = blockSize;
-            _i2sBufDesc[indexDesc].buf_ptr = reinterpret_cast<uint32_t>(is2Buffer);
+            _i2sBufDesc[indexDesc].buf_ptr = is2Buffer;
             _i2sBufDesc[indexDesc].unused = 0;
-            _i2sBufDesc[indexDesc].next_link_ptr = reinterpret_cast<uint32_t>(&(_i2sBufDesc[indexDesc + 1]));
+            _i2sBufDesc[indexDesc].next_link_ptr = &(_i2sBufDesc[indexDesc + 1]);
 
             is2Buffer += blockSize;
             is2BufferSize -= blockSize;
@@ -330,15 +330,15 @@ public:
             _i2sBufDesc[indexDesc].sub_sof = 0;
             _i2sBufDesc[indexDesc].datalen = sizeof(_i2sZeroes);
             _i2sBufDesc[indexDesc].blocksize = sizeof(_i2sZeroes);
-            _i2sBufDesc[indexDesc].buf_ptr = reinterpret_cast<uint32_t>(_i2sZeroes);
+            _i2sBufDesc[indexDesc].buf_ptr = _i2sZeroes;
             _i2sBufDesc[indexDesc].unused = 0;
-            _i2sBufDesc[indexDesc].next_link_ptr = reinterpret_cast<uint32_t>(&(_i2sBufDesc[indexDesc + 1]));
+            _i2sBufDesc[indexDesc].next_link_ptr = &(_i2sBufDesc[indexDesc + 1]);
         }
 
         // the first state block will trigger the interrupt
         _i2sBufDesc[indexDesc - 2].eof = 1;
         // the last state block will loop to the first state block by defualt
-        _i2sBufDesc[indexDesc - 1].next_link_ptr = reinterpret_cast<uint32_t>(&(_i2sBufDesc[indexDesc - 2]));
+        _i2sBufDesc[indexDesc - 1].next_link_ptr = &(_i2sBufDesc[indexDesc - 2]);
 
         // setup the rest of i2s DMA
         //
@@ -476,7 +476,7 @@ private:
 
                     // data block has pending data waiting to send, prepare it
                     // point last state block to top 
-                    (finished_item + 1)->next_link_ptr = reinterpret_cast<uint32_t>(s_this->_i2sBufDesc);
+                    (finished_item + 1)->next_link_ptr = s_this->_i2sBufDesc;
 
                     s_this->_dmaState = NeoDmaState_Sending;
                 }
@@ -489,7 +489,7 @@ private:
                     // the data block had actual data sent
                     // point last state block to first state block thus
                     // just looping and not sending the data blocks
-                    (finished_item + 1)->next_link_ptr = reinterpret_cast<uint32_t>(finished_item);
+                    (finished_item + 1)->next_link_ptr = reinterpret_cast<uint32*>(finished_item);
 
                     s_this->_dmaState = NeoDmaState_Zeroing;
                 }


### PR DESCRIPTION
clang-tidy reports:

```
./src/internal/NeoEsp8266DmaMethod.h:317:46: error: cast from pointer to smaller type 'uint32_t' (aka 'unsigned int') loses information [clang-diagnostic-error]
            _i2sBufDesc[indexDesc].buf_ptr = reinterpret_cast<uint32_t>(is2Buffer);
                                             ^
./src/internal/NeoEsp8266DmaMethod.h:492:58: error: cast from pointer to smaller type 'uint32_t' (aka 'unsigned int') loses information [clang-diagnostic-error]
                    (finished_item + 1)->next_link_ptr = reinterpret_cast<uint32_t>(finished_item);
```

Use pointers instead of integers for pointers. This makes quite some
casts unnecessary.