### PR TITLE
only ESP32 and ESP32S2

### DIFF
--- a/src/internal/Esp32_i2s.c
+++ b/src/internal/Esp32_i2s.c
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 // ESP32C3 I2S is not supported yet due to significant changes to interface
-#if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)
 
 #include <string.h>
 #include <stdio.h>

--- a/src/internal/Esp32_i2s.h
+++ b/src/internal/Esp32_i2s.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // ESP32C3 I2S is not supported yet due to significant changes to interface
-#if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/internal/NeoEsp32I2sMethod.h
+++ b/src/internal/NeoEsp32I2sMethod.h
@@ -27,7 +27,7 @@ License along with NeoPixel.  If not, see
 #pragma once
 
 // ESP32C3 I2S is not supported yet due to significant changes to interface
-#if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)
 
 extern "C"
 {

--- a/src/internal/NeoEspBitBangMethod.cpp
+++ b/src/internal/NeoEspBitBangMethod.cpp
@@ -24,7 +24,8 @@ License along with NeoPixel.  If not, see
 <http://www.gnu.org/licenses/>.
 -------------------------------------------------------------------------*/
 
-#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+// ESP32C3 I2S is not supported yet due to significant changes to interface
+#if defined(ARDUINO_ARCH_ESP8266) || defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)
 
 #include <Arduino.h>
 


### PR DESCRIPTION
Not working `#if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)`
Replaced by `#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)`