### PR TITLE
Change to SPI2_HOST for esp32c3 and avoid duplicate in Tasmota

### DIFF
--- a/src/internal/DotStarEsp32DmaSpiMethod.h
+++ b/src/internal/DotStarEsp32DmaSpiMethod.h
@@ -29,9 +29,9 @@ License along with NeoPixel.  If not, see
 
 #include "driver/spi_master.h"
 
-#if defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(HSPI_HOST)
 // HSPI_HOST depreciated in C3
-#define HSPI_HOST   SPI3_HOST
+#define HSPI_HOST   SPI2_HOST
 #endif
 
 #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)


### PR DESCRIPTION
`HSPI_HOST` is now defined in Tasmota, so this creates a compiler warning. I propose to test existence of it before defining it.

Also, it looks like there is no SPI3_HOST on Esp32c3, as mentioned here:

```
/* No SPI3_host on C3 */
#define SPI_HOST    SPI1_HOST
#define FSPI_HOST   SPI2_HOST
#define HSPI_HOST   SPI2_HOST
```

https://github.com/espressif/esp-idf/blob/c438ad5d72a835c2447b8cb236d922c1f1dbaa3d/components/hal/include/hal/spi_types.h#L57-L62