### PR TITLE
i2s.h conflict change

### DIFF
--- a/src/internal/NeoEsp8266DmaMethod.h
+++ b/src/internal/NeoEsp8266DmaMethod.h
@@ -39,7 +39,7 @@ extern "C"
 #include "ets_sys.h"
 
 #include "i2s_reg.h"
-#include "i2s.h"
+#include "core_esp8266_i2s.h"
 #include "eagle_soc.h"
 #include "esp8266_peri.h"
 #include "slc_register.h"


### PR DESCRIPTION
ESP8266 Arduino v3.1 will remove the i2s.h due to name conflict when used on case insensitive file systems.