### PR TITLE
Fix missing clang-tidy missing IRAM_ATTR

### DIFF
--- a/src/internal/NeoEsp8266DmaMethod.h
+++ b/src/internal/NeoEsp8266DmaMethod.h
@@ -32,9 +32,10 @@ License along with NeoPixel.  If not, see
 
 #ifdef ARDUINO_ARCH_ESP8266
 
+#include "Arduino.h"
+
 extern "C"
 {
-#include "Arduino.h"
 #include "osapi.h"
 #include "ets_sys.h"
 


### PR DESCRIPTION
It seems that IRAM_ATTR is not defined when clang-tidy checks leading to
errors like the following:

```
Error: /__w/esphome/esphome/.pio/libdeps/livingroom8266/NeoPixelBus/src/internal/NeoEsp8266DmaMethod.h:244:17: error: variable has incomplete type 'void' [clang-diagnostic-error]
    static void IRAM_ATTR i2s_slc_isr(void)
                ^
```

Include Arduino.h in global context just like in other header files
makes sure that IRAM_ATTR is defined in all cases.