### PR TITLE
Add NeoBusChannel constructor to NeoPixelBrightnessBus

### DIFF
--- a/src/NeoPixelBrightnessBus.h
+++ b/src/NeoPixelBrightnessBus.h
@@ -70,6 +70,12 @@ public:
         _brightness(255)
     {
     }
+    
+    NeoPixelBrightnessBus(uint16_t countPixels, uint8_t pin, NeoBusChannel channel) :
+        NeoPixelBus<T_COLOR_FEATURE, T_METHOD>(countPixels, pin, channel),
+        _brightness(255)
+    {
+    }
 
     NeoPixelBrightnessBus(uint16_t countPixels, uint8_t pinClock, uint8_t pinData) :
         NeoPixelBus<T_COLOR_FEATURE, T_METHOD>(countPixels, pinClock, pinData),


### PR DESCRIPTION
Hey!

Using NeoBusChannel with the method `NeoEsp32RmtNWs2812xMethod` works fine with `NeoPixelBus`, but leads to a compilation error when using `NeoPixelBrightnessBus`. (NeoPixelBrightnessBus will instead call the NeoPixelBus constructor with two pin arguments for clocked LEDs).

To reproduce, use in NeoPixelTest.ino:

```cpp
NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp32RmtNWs2812xMethod> strip(PixelCount, PixelPin, (NeoBusChannel)0);
```

NeoPixelBrightnessBus is lacking a constructor with arguments (uint16_t countPixels, uint8_t pin, NeoBusChannel channel). This PR adds this constructor, which fixes the problem.

Thank you very much for NeoPixelBus :)

