### PR TITLE
Restored compatibility with ESP8266 Arduino Core < 3.0.1

### DIFF
--- a/src/internal/NeoEsp8266DmaMethod.h
+++ b/src/internal/NeoEsp8266DmaMethod.h
@@ -40,7 +40,13 @@ extern "C"
 #include "ets_sys.h"
 
 #include "i2s_reg.h"
-#include "core_esp8266_i2s.h"
+
+#ifdef ARDUINO_ESP8266_MAJOR    //this define was added in ESP8266 Arduino Core version v3.0.1
+  #include "core_esp8266_i2s.h" //for Arduino core >= 3.0.1
+#else
+  #include "i2s.h"              //for Arduino core <= 3.0.0
+#endif
+
 #include "eagle_soc.h"
 #include "esp8266_peri.h"
 #include "slc_register.h"


### PR DESCRIPTION
#486 broke compatibility with all ESP8266 Arduino core versions but the most recent 3.0.1 one. Support for the latest version is of course the most important, still more compatibility is nice as long as it doesn't cause extra maintainance.

Version 3.0.1 added the macro `ARDUINO_ESP8266_MAJOR` in `cores/esp8266/core_version.h` (https://github.com/esp8266/Arduino/pull/8126), so it can be used to distinguish 3.0.1 and future releases that need to include `core_esp8266_i2s.h` from previous versions that need to include `i2s.h`.

Verified working in Arduino Core 2.7.4, 3.0.0 and 3.0.1.