### PR TITLE
Fix initialization of RMT config

### DIFF
--- a/src/internal/NeoEsp32RmtMethod.h
+++ b/src/internal/NeoEsp32RmtMethod.h
@@ -537,7 +537,7 @@ public:
 
     void Initialize()
     {
-        rmt_config_t config;
+        rmt_config_t config = {};
 
         config.rmt_mode = RMT_MODE_TX;
         config.channel = _channel.RmtChannelNumber;


### PR DESCRIPTION
In IDF v4 new fields were added to the config struct, not initializing it messed up the clock