### PR TITLE
Use default parameters for rmt_driver_install

### DIFF
--- a/src/internal/NeoEsp32RmtMethod.h
+++ b/src/internal/NeoEsp32RmtMethod.h
@@ -554,7 +554,7 @@ public:
         config.clk_div = T_SPEED::RmtClockDivider;
 
         ESP_ERROR_CHECK(rmt_config(&config));
-        ESP_ERROR_CHECK(rmt_driver_install(_channel.RmtChannelNumber, 0, ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_LEVEL1));
+        ESP_ERROR_CHECK(rmt_driver_install(_channel.RmtChannelNumber, 0, 0));
         ESP_ERROR_CHECK(rmt_translator_init(_channel.RmtChannelNumber, T_SPEED::Translate));
     }
 

--- a/src/internal/NeoEsp32RmtMethod.h
+++ b/src/internal/NeoEsp32RmtMethod.h
@@ -554,7 +554,7 @@ public:
         config.clk_div = T_SPEED::RmtClockDivider;
 
         ESP_ERROR_CHECK(rmt_config(&config));
-        ESP_ERROR_CHECK(rmt_driver_install(_channel.RmtChannelNumber, 0, 0));
+        ESP_ERROR_CHECK(rmt_driver_install(_channel.RmtChannelNumber, 0, ESP_INTR_FLAG_LOWMED));
         ESP_ERROR_CHECK(rmt_translator_init(_channel.RmtChannelNumber, T_SPEED::Translate));
     }
 


### PR DESCRIPTION
In Tasmota, since esp-idf 4.4, we observe ESP32 crashes when an RMT Tx buffer is transmitting and a SPI Flash operation happens at the same time.

It seems to be an interrupt conflict. Setting default parameters to `rmt_driver_install()` solves the issue. Actually all Espressif examples use the default interrupt value and don't set `ESP_INTR_FLAG_IRAM`