### PR TITLE
Disable I2S for ESP32S3 and allow compilation

### DIFF
--- a/src/internal/Esp32_i2s.c
+++ b/src/internal/Esp32_i2s.c
@@ -19,8 +19,8 @@
 
 #include "sdkconfig.h" // this sets useful config symbols, like CONFIG_IDF_TARGET_ESP32C3
 
-// ESP32C3 I2S is not supported yet due to significant changes to interface
-#if !defined(CONFIG_IDF_TARGET_ESP32C3)
+// ESP32C3/S3 I2S is not supported yet due to significant changes to interface
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
 
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
Quick change proposed to make NeoPixelBus compile for Esp32S3.

It works fine on Esp32S3 with RMT.