### PR TITLE
fix-brightness-issue-375

### DIFF
--- a/examples/NeoPixelBrightness/NeoPixelBrightness.ino
+++ b/examples/NeoPixelBrightness/NeoPixelBrightness.ino
@@ -1,10 +1,10 @@
 // NeoPixelBrightness
 // This example will cycle brightness from high to low of
-// three pixels colored Red, Green, Blue.  
-// This demonstrates the use of the NeoPixelBrightnessBus 
+// three pixels colored Red, Green, Blue.
+// This demonstrates the use of the NeoPixelBrightnessBus
 // with integrated brightness support
 //
-// There is serial output of the current state so you can 
+// There is serial output of the current state so you can
 // confirm and follow along
 //
 
@@ -24,7 +24,7 @@ NeoPixelBrightnessBus<NeoRgbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPi
 
 // you loose the original color the lower the dim value used
 // here due to quantization
-const uint8_t c_MinBrightness = 8; 
+const uint8_t c_MinBrightness = 8;
 const uint8_t c_MaxBrightness = 255;
 
 int8_t direction; // current direction of dimming
@@ -43,7 +43,7 @@ void setup()
     strip.Show();
 
     direction = -1; // default to dim first
-    
+
     Serial.println();
     Serial.println("Running...");
 
@@ -51,7 +51,7 @@ void setup()
     strip.SetPixelColor(0, red);
     strip.SetPixelColor(1, green);
     strip.SetPixelColor(2, blue);
-  
+
     strip.Show();
 }
 
@@ -60,7 +60,7 @@ void loop()
 {
     uint8_t brightness = strip.GetBrightness();
     Serial.println(brightness);
-    
+
     delay(100);
 
     // swap diection of dim when limits are reached
@@ -75,6 +75,10 @@ void loop()
     }
     // apply dimming
     brightness += direction;
+
+    strip.SetPixelColor(0, red);
+    strip.SetPixelColor(1, green);
+    strip.SetPixelColor(2, blue);
     strip.SetBrightness(brightness);
 
     // show the results


### PR DESCRIPTION
Added the few lines suggested in #375 to the NeoPixelBusBrightness.ino required to be able to close this enhancement of the brightness example code. It caused some confusion for me when I tried to understand why pixels died after a few cycles. However, I have tested the fix on my ESP8266 and can confirm it works as expected.