### PR TITLE
Allow ESP32-C3 to use bitbang method

### DIFF
--- a/src/internal/NeoEspBitBangMethod.cpp
+++ b/src/internal/NeoEspBitBangMethod.cpp
@@ -29,12 +29,15 @@ License along with NeoPixel.  If not, see
 #include <Arduino.h>
 
 // ESP32C3 I2S is not supported yet 
-#if !defined(CONFIG_IDF_TARGET_ESP32C3)
 
 static inline uint32_t getCycleCount(void)
 {
     uint32_t ccount;
+#if !defined(CONFIG_IDF_TARGET_ESP32C3)
     __asm__ __volatile__("rsr %0,ccount":"=a" (ccount));
+#else
+    ccount = esp_cpu_get_ccount();
+#endif
     return ccount;
 }
 
@@ -263,5 +266,4 @@ void IRAM_ATTR NeoEspBitBangBase_send_pixels_inv_pin16(uint8_t *pixels, uint8_t 
     }
 }
 #endif // defined(ARDUINO_ARCH_ESP8266)
-#endif // !defined(CONFIG_IDF_TARGET_ESP32C3)
 #endif //  defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)

--- a/src/internal/NeoEspBitBangMethod.cpp
+++ b/src/internal/NeoEspBitBangMethod.cpp
@@ -64,7 +64,7 @@ void IRAM_ATTR NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end, uint
 
         // set pin state
 #if defined(ARDUINO_ARCH_ESP32)
-        GPIO.out_w1ts = pinRegister;
+        GPIO.out_w1ts.val = pinRegister;
 #else
         GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
 #endif
@@ -74,7 +74,7 @@ void IRAM_ATTR NeoEspBitBangBase_send_pixels(uint8_t* pixels, uint8_t* end, uint
 
         // reset pin start
 #if defined(ARDUINO_ARCH_ESP32)
-        GPIO.out_w1tc = pinRegister;
+        GPIO.out_w1tc.val = pinRegister;
 #else
         GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
 #endif
@@ -177,7 +177,7 @@ void IRAM_ATTR NeoEspBitBangBase_send_pixels_inv(uint8_t* pixels, uint8_t* end, 
 
         // set pin state
 #if defined(ARDUINO_ARCH_ESP32)
-        GPIO.out_w1tc = pinRegister;
+        GPIO.out_w1tc.val = pinRegister;
 #else
         GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinRegister);
 #endif
@@ -187,7 +187,7 @@ void IRAM_ATTR NeoEspBitBangBase_send_pixels_inv(uint8_t* pixels, uint8_t* end, 
 
         // reset pin start
 #if defined(ARDUINO_ARCH_ESP32)
-        GPIO.out_w1ts = pinRegister;
+        GPIO.out_w1ts.val = pinRegister;
 #else
         GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinRegister);
 #endif

--- a/src/internal/NeoEspBitBangMethod.h
+++ b/src/internal/NeoEspBitBangMethod.h
@@ -28,9 +28,6 @@ License along with NeoPixel.  If not, see
 
 #if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
 
-// ESP32C3 I2S is not supported yet 
-#if !defined(CONFIG_IDF_TARGET_ESP32C3)
-
 #if defined(ARDUINO_ARCH_ESP8266)
 #include <eagle_soc.h>
 #endif

--- a/src/internal/NeoEspBitBangMethod.h
+++ b/src/internal/NeoEspBitBangMethod.h
@@ -396,5 +396,4 @@ typedef NeoEsp8266BitBangSk6812InvertedMethod NeoEsp8266BitBangLc8812InvertedMet
 
 // ESP bitbang doesn't have defaults and should avoided except for testing
 
-#endif // !defined(CONFIG_IDF_TARGET_ESP32C3)
 #endif // defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)


### PR DESCRIPTION
The RMT method timing is not entirely stable on the ESP32-C3. Hooking up a scope or logic analyzer would be a good idea to get this dialed in.
In the meantime, the bitbang method is totally reliable and only needs these minor fixes to work. These changes likely also are necessary for the latest version of the espressif SDK with the need to use the `GPIO.out_w1t[s/c].val` member to assign the `pinRegister`.