### PR TITLE
Add support for ESP32-S3 8 bit SPI DMA method

### DIFF
--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -186,6 +186,13 @@ public:
         ClearTo(0);
     }
 
+    // used by DotStarEsp32DmaSpiMethod if pins can be configured - reordered and extended version supporting oct SPI
+    void Begin(int8_t sck, int8_t dat0, int8_t dat1, int8_t dat2, int8_t dat3, int8_t dat4, int8_t dat5, int8_t dat6, int8_t dat7, int8_t ss)
+    {
+        _method.Initialize(sck, dat0, dat1, dat2, dat3, dat4, dat5, dat6, dat7, ss);
+        ClearTo(0);
+    }
+
     void Show(bool maintainBufferConsistency = true)
     {
         if (!IsDirty())

--- a/src/internal/DotStarEsp32DmaSpiMethod.h
+++ b/src/internal/DotStarEsp32DmaSpiMethod.h
@@ -208,7 +208,10 @@ public:
 
     void Update(bool)
     {
-        while(!IsReadyToUpdate()) portYIELD();
+        while(!IsReadyToUpdate()) 
+        {
+            portYIELD();
+        }
 
         memcpy(_dmadata, _data, _spiBufferSize);
 

--- a/src/internal/DotStarEsp32DmaSpiMethod.h
+++ b/src/internal/DotStarEsp32DmaSpiMethod.h
@@ -40,7 +40,6 @@ class Esp32VspiBus
 {
 public:
     const static spi_host_device_t SpiHostDevice = VSPI_HOST;
-    const static int DmaChannel = 1;    // arbitrary assignment, but based on the fact there are only two DMA channels and two available SPI ports, we need to split them somehow
     const static int ParallelBits = 1;
 };
 #endif
@@ -49,7 +48,6 @@ class Esp32HspiBus
 {
 public:
     const static spi_host_device_t SpiHostDevice = HSPI_HOST;
-    const static int DmaChannel = 2;    // arbitrary assignment, but based on the fact there are only two DMA channels and two available SPI ports, we need to split them somehow
     const static int ParallelBits = 1;
 };
 
@@ -58,7 +56,6 @@ class Esp32Vspi2BitBus
 {
 public:
     const static spi_host_device_t SpiHostDevice = VSPI_HOST;
-    const static int DmaChannel = 1;    // arbitrary assignment, but based on the fact there are only two DMA channels and two available SPI ports, we need to split them somehow
     const static int ParallelBits = 2;
 };
 #endif
@@ -67,7 +64,6 @@ class Esp32Hspi2BitBus
 {
 public:
     const static spi_host_device_t SpiHostDevice = HSPI_HOST;
-    const static int DmaChannel = 2;    // arbitrary assignment, but based on the fact there are only two DMA channels and two available SPI ports, we need to split them somehow
     const static int ParallelBits = 2;
 };
 
@@ -76,7 +72,6 @@ class Esp32Vspi4BitBus
 {
 public:
     const static spi_host_device_t SpiHostDevice = VSPI_HOST;
-    const static int DmaChannel = 1;    // arbitrary assignment, but based on the fact there are only two DMA channels and two available SPI ports, we need to split them somehow
     const static int ParallelBits = 4;
 };
 #endif
@@ -85,7 +80,6 @@ class Esp32Hspi4BitBus
 {
 public:
     const static spi_host_device_t SpiHostDevice = HSPI_HOST;
-    const static int DmaChannel = 2;    // arbitrary assignment, but based on the fact there are only two DMA channels and two available SPI ports, we need to split them somehow
     const static int ParallelBits = 4;
 };
 
@@ -161,7 +155,7 @@ public:
         buscfg.max_transfer_sz = _spiBufferSize;
 
         //Initialize the SPI bus
-        ret = spi_bus_initialize(T_SPIBUS::SpiHostDevice, &buscfg, T_SPIBUS::DmaChannel);
+        ret = spi_bus_initialize(T_SPIBUS::SpiHostDevice, &buscfg, SPI_DMA_CH_AUTO);
         ESP_ERROR_CHECK(ret);
 
         initSpiDevice();
@@ -212,7 +206,6 @@ public:
         _spiTransaction.tx_buffer = _dmadata;
 
         esp_err_t ret = spi_device_queue_trans(_spiHandle, &_spiTransaction, 0);  //Transmit!
-        assert(ret == ESP_OK);            //Should have had no issues.
     }
 
     uint8_t* getData() const


### PR DESCRIPTION
Surgical change to add 8 bit support for ESP32-S3. 
* Fix DMA channel selection bug. It must be AUTO for S3
* Add 8 bit HSPI bus
* Known bug: HSPI is SPI3 on ESP32-S2 which doesn't support 2 and 4 bit modes. 
* Known bug: SPI2 on the S2 is called FSPI and it supports up to 8 channels

Those bugs aren't introduced by this PR nor are they fixed by it. I am documenting them here because I encountered them when testing my changes against different flavors of ESP32

Partially addresses #605 