### PR TITLE
Fix for 622 and 624

### DIFF
--- a/src/internal/NeoGamma.h
+++ b/src/internal/NeoGamma.h
@@ -32,11 +32,11 @@ class NeoGammaEquationMethod
 public:
     static uint8_t Correct(uint8_t value)
     {
-        return static_cast<uint8_t>(255.0f * NeoEase::Gamma(value / 255.0f) + 0.5f);
+        return static_cast<uint8_t>(255.0f * NeoEase::Gamma((float)value / 255.0f) + 0.5f);
     }
     static uint16_t Correct(uint16_t value)
     {
-        return static_cast<uint16_t>(65535.0f * NeoEase::Gamma(value / 65535.0f) + 0.5f);
+        return static_cast<uint16_t>(65535.0f * NeoEase::Gamma((float)value / 65535.0f) + 0.5f);
     }
 };
 
@@ -82,7 +82,7 @@ public:
 
     Rgb48Color Correct(const Rgb48Color& original)
     {
-        return RgbColor(T_METHOD::Correct(original.R),
+        return Rgb48Color(T_METHOD::Correct(original.R),
             T_METHOD::Correct(original.G),
             T_METHOD::Correct(original.B));
     }

--- a/src/internal/Rgb48Color.cpp
+++ b/src/internal/Rgb48Color.cpp
@@ -135,9 +135,9 @@ void Rgb48Color::Lighten(uint16_t delta)
 
 Rgb48Color Rgb48Color::LinearBlend(const Rgb48Color& left, const Rgb48Color& right, float progress)
 {
-    return Rgb48Color( left.R + (((int32_t)right.R - left.R) * progress),
-        left.G + (((int32_t)right.G - left.G) * progress),
-        left.B + (((int32_t)right.B - left.B) * progress));
+    return Rgb48Color( left.R + (((float)right.R - (float)left.R) * progress),
+        left.G + (((float)right.G - (float)left.G) * progress),
+        left.B + (((float)right.B - (float)left.B) * progress));
 }
 
 Rgb48Color Rgb48Color::BilinearBlend(const Rgb48Color& c00, 

--- a/src/internal/Rgb48Color.cpp
+++ b/src/internal/Rgb48Color.cpp
@@ -135,9 +135,9 @@ void Rgb48Color::Lighten(uint16_t delta)
 
 Rgb48Color Rgb48Color::LinearBlend(const Rgb48Color& left, const Rgb48Color& right, float progress)
 {
-    return Rgb48Color( left.R + (((float)right.R - (float)left.R) * progress),
-        left.G + (((float)right.G - (float)left.G) * progress),
-        left.B + (((float)right.B - (float)left.B) * progress));
+    return Rgb48Color( left.R + ((float)(right.R - left.R) * progress),
+        left.G + ((float)(right.G - left.G) * progress),
+        left.B + ((float)(right.B - left.B) * progress));
 }
 
 Rgb48Color Rgb48Color::BilinearBlend(const Rgb48Color& c00, 

--- a/src/internal/Rgbw64Color.cpp
+++ b/src/internal/Rgbw64Color.cpp
@@ -162,10 +162,10 @@ void Rgbw64Color::Lighten(uint16_t delta)
 
 Rgbw64Color Rgbw64Color::LinearBlend(const Rgbw64Color& left, const Rgbw64Color& right, float progress)
 {
-    return Rgbw64Color( left.R + (((float)right.R - (float)left.R) * progress),
-        left.G + (((float)right.G - (float)left.G) * progress),
-        left.B + (((float)right.B - (float)left.B) * progress),
-        left.W + (((float)right.W - (float)left.W) * progress) );
+    return Rgbw64Color( left.R + ((float)(right.R - left.R) * progress),
+        left.G + ((float)(right.G - left.G) * progress),
+        left.B + ((float)(right.B - left.B) * progress),
+        left.W + ((float)(right.W - left.W) * progress) );
 }
 
 Rgbw64Color Rgbw64Color::BilinearBlend(const Rgbw64Color& c00, 

--- a/src/internal/Rgbw64Color.cpp
+++ b/src/internal/Rgbw64Color.cpp
@@ -162,10 +162,10 @@ void Rgbw64Color::Lighten(uint16_t delta)
 
 Rgbw64Color Rgbw64Color::LinearBlend(const Rgbw64Color& left, const Rgbw64Color& right, float progress)
 {
-    return Rgbw64Color( left.R + (((int32_t)right.R - left.R) * progress),
-        left.G + (((int32_t)right.G - left.G) * progress),
-        left.B + (((int32_t)right.B - left.B) * progress),
-        left.W + (((int32_t)right.W - left.W) * progress) );
+    return Rgbw64Color( left.R + (((float)right.R - (float)left.R) * progress),
+        left.G + (((float)right.G - (float)left.G) * progress),
+        left.B + (((float)right.B - (float)left.B) * progress),
+        left.W + (((float)right.W - (float)left.W) * progress) );
 }
 
 Rgbw64Color Rgbw64Color::BilinearBlend(const Rgbw64Color& c00, 


### PR DESCRIPTION
casted uint16_t to float, in order to get the correct result off * and /
corrected result type for NeoGamma::Correct(const Rgb48Color& original)