### PR TITLE
DotStarEsp32DmaSpiMethod: adjust start+end frames to reflect bus width

### DIFF
--- a/src/internal/DotStarEsp32DmaSpiMethod.h
+++ b/src/internal/DotStarEsp32DmaSpiMethod.h
@@ -36,8 +36,9 @@ public:
     typedef typename T_SPISPEED::SettingsObject SettingsObject;
 
     _DotStarEsp32DmaSpiMethod(uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
+        _sizeStartFrame(4 * T_SPIBUS::ParallelBits),
         _sizePixelData(pixelCount * elementSize + settingsSize),
-        _sizeEndFrame((pixelCount + 15) / 16) // 16 = div 2 (bit for every two pixels) div 8 (bits to bytes)
+        _sizeEndFrame((pixelCount + 15) / 16 * T_SPIBUS::ParallelBits) // 16 = div 2 (bit for every two pixels) div 8 (bits to bytes)
     {
         _spiBufferSize = _sizeStartFrame + _sizePixelData + _sizeEndFrame;
 
@@ -233,7 +234,7 @@ private:
         ESP_ERROR_CHECK(ret);
     }
 
-    const size_t             _sizeStartFrame = 4;
+    const size_t             _sizeStartFrame;
     const size_t             _sizePixelData;   // Size of '_data' buffer below, minus (_sizeStartFrame + _sizeEndFrame)
     const size_t             _sizeEndFrame;
 


### PR DESCRIPTION
The start and end frame bits get smeared over the bus's data lines. Fortunately, they are all 0s so it's easy to scale them.