### PR TITLE
Fixed bug where SPI driver would hang if not initialized properly

### DIFF
--- a/src/internal/DotStarEsp32DmaSpiMethod.h
+++ b/src/internal/DotStarEsp32DmaSpiMethod.h
@@ -116,7 +116,8 @@ public:
         //Initialize the SPI bus
         ret = spi_bus_initialize(T_SPIBUS::SpiHostDevice, &buscfg, SPI_DMA_CH_AUTO);
         ESP_ERROR_CHECK(ret);
-
+        
+        memset(&_spiTransaction, 0, sizeof(spi_transaction_t));
         initSpiDevice();
     }
 


### PR DESCRIPTION
Sometimes the SPI driver would hang when Update was called due to the internal txn handle being initialized with random memory