### PR TITLE
Add RgbwwColor to NeoGamma

### DIFF
--- a/src/internal/colors/NeoGamma.h
+++ b/src/internal/colors/NeoGamma.h
@@ -66,6 +66,15 @@ public:
             T_METHOD::Correct(original.B),
             T_METHOD::Correct(original.W));
     }
+
+    static RgbwwColor Correct(const RgbwwColor& original)
+    {
+        return RgbwwColor(T_METHOD::Correct(original.R),
+            T_METHOD::Correct(original.G),
+            T_METHOD::Correct(original.B),
+            T_METHOD::Correct(original.WW),
+            T_METHOD::Correct(original.CW));
+    }
 };
 
 


### PR DESCRIPTION
Spotted during implementation of RGBWW support in WLED. Allows to use RgbwwColor in NeoGammaNullMethod and similar.