### PR TITLE
Support for Adafruit Pixie

### DIFF
--- a/examples/PixieSerial/PixieSerial.ino
+++ b/examples/PixieSerial/PixieSerial.ino
@@ -1,0 +1,93 @@
+// PixieTest
+// This example will cycle between showing Pixies as Red, Green, Blue, White
+// and then showing those Pixies as Black.
+//
+// There is serial output of the current state so you can confirm and follow along
+//
+
+#include <NeoPixelBus.h>
+
+const uint16_t PixelCount = 1; // Number of Pixies daisycahined
+
+#define colorSaturation 128
+
+// Pixie reads data in at 115.2k serial, 8N1.
+// Byte order is R1, G1, B1, R2, G2, B2, ... where the first triplet is the
+// color of the LED that's closest to the controller. 1ms of silence triggers
+// latch. 2 seconds silence (or overheating) triggers LED off (for safety).
+
+// Use either Software Serial or hardwar serial depending on the board
+
+// #include "SoftwareSerial.h"
+// #define PIXIEPIN  6 // Pin number for SoftwareSerial output
+// SoftwareSerial pixieSerial(-1, PIXIEPIN);
+
+//hardware Serial
+#define pixieSerial Serial2
+
+NeoPixelBus<NeoRgbFeature, PixieSerialMethod> strip(PixelCount, &pixieSerial);
+
+RgbColor colors[5];
+HslColor hslColors[5];
+
+
+void setup()
+{
+    Serial.begin(115200);
+    while (!Serial); // wait for serial attach
+
+    Serial.println();
+    Serial.println("Initializing...");
+    Serial.flush();
+
+    pixieSerial.begin(115200); // Pixie requires 115200
+
+    //setup array of colors (R,G,B,W,Black)
+    colors[0] = RgbColor(colorSaturation, 0, 0);
+    colors[1] = RgbColor(0, colorSaturation, 0);
+    colors[2] = RgbColor(0, 0, colorSaturation);
+    colors[3] = RgbColor(colorSaturation);
+    colors[4] = RgbColor(0);
+
+    hslColors[0] = HslColor(colors[0]);
+    hslColors[1] = HslColor(colors[1]);
+    hslColors[2] = HslColor(colors[2]);
+    hslColors[3] = HslColor(colors[3]);
+    hslColors[4] = HslColor(colors[4]);
+
+    // this resets all the neopixels to an off state
+    strip.Begin();
+    strip.Show();
+
+    Serial.println();
+    Serial.println("Running...");
+}
+
+
+void loop()
+{
+    Serial.println("RGB Colors R, G, B, W, Off");
+    //set all the Pixies to Red->Green->Blue->White->Black/Off
+    for(int j=0; j<5; j++)
+    {
+      for(int i=0; i<PixelCount; i++)
+      {
+        strip.SetPixelColor(i, colors[j]);
+      }
+      strip.Show();
+      delay(1000);
+    }
+    
+    Serial.println("HSL Colors R, G, B, W, Off");
+    //set all the Pixies to HSL Red->Green->Blue->White->Black/Off
+    for(int j=0; j<5; j++)
+    {
+      for(int i=0; i<PixelCount; i++)
+      {
+        strip.SetPixelColor(i, hslColors[j]);
+      }
+      strip.Show();
+      delay(1000);
+    }
+
+}

--- a/examples/PixieSerial/PixieSerial.ino
+++ b/examples/PixieSerial/PixieSerial.ino
@@ -16,7 +16,7 @@ const uint16_t PixelCount = 1; // Number of Pixies daisycahined
 // color of the LED that's closest to the controller. 1ms of silence triggers
 // latch. 2 seconds silence (or overheating) triggers LED off (for safety).
 
-// Use either Software Serial or hardwar serial depending on the board
+// Use either Software Serial or hardware serial depending on the board
 
 // #include "SoftwareSerial.h"
 // #define PIXIEPIN  6 // Pin number for SoftwareSerial output
@@ -25,11 +25,9 @@ const uint16_t PixelCount = 1; // Number of Pixies daisycahined
 //hardware Serial
 #define pixieSerial Serial2
 
-NeoPixelBus<NeoRgbFeature, PixieSerialMethod> strip(PixelCount, &pixieSerial);
+NeoPixelBus<NeoRgbFeature, PixieStreamMethod> strip(PixelCount, &pixieSerial);
 
 RgbColor colors[5];
-HslColor hslColors[5];
-
 
 void setup()
 {
@@ -40,7 +38,8 @@ void setup()
     Serial.println("Initializing...");
     Serial.flush();
 
-    pixieSerial.begin(115200); // Pixie requires 115200
+    // Pixie requires 115200 buard rate and 8N1 (eight bits, no parity, 1 stop bit). 
+    pixieSerial.begin(115200, SERIAL_8N1); 
 
     //setup array of colors (R,G,B,W,Black)
     colors[0] = RgbColor(colorSaturation, 0, 0);
@@ -49,13 +48,7 @@ void setup()
     colors[3] = RgbColor(colorSaturation);
     colors[4] = RgbColor(0);
 
-    hslColors[0] = HslColor(colors[0]);
-    hslColors[1] = HslColor(colors[1]);
-    hslColors[2] = HslColor(colors[2]);
-    hslColors[3] = HslColor(colors[3]);
-    hslColors[4] = HslColor(colors[4]);
-
-    // this resets all the neopixels to an off state
+    // this resets all the Pixies to an off state
     strip.Begin();
     strip.Show();
 
@@ -67,27 +60,19 @@ void setup()
 void loop()
 {
     Serial.println("RGB Colors R, G, B, W, Off");
-    //set all the Pixies to Red->Green->Blue->White->Black/Off
-    for(int j=0; j<5; j++)
+    // Cycle all the Pixies through Red->Green->Blue->White->Black/Off from the colors array
+    for(int colorIndex=0; colorIndex<5; colorIndex++)
     {
-      for(int i=0; i<PixelCount; i++)
+      for(int pixelIndex=0; pixelIndex<PixelCount; pixelIndex++)
       {
-        strip.SetPixelColor(i, colors[j]);
+        strip.SetPixelColor(pixelIndex, colors[colorIndex]);
       }
-      strip.Show();
+      strip.Show(); 
       delay(1000);
-    }
-    
-    Serial.println("HSL Colors R, G, B, W, Off");
-    //set all the Pixies to HSL Red->Green->Blue->White->Black/Off
-    for(int j=0; j<5; j++)
-    {
-      for(int i=0; i<PixelCount; i++)
-      {
-        strip.SetPixelColor(i, hslColors[j]);
-      }
-      strip.Show();
-      delay(1000);
+      // As a safety feature, Pixie will shutoff if no data is received >2 seconds
+      // Adafruit recomends sending data <1 second.  If needed, .Show() can be called 
+      // again to resend the existing color value to reset this timer.
+      
     }
 
 }

--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -84,6 +84,13 @@ public:
     {
     }
 
+    NeoPixelBus(uint16_t countPixels, Stream *s) :
+        _countPixels(countPixels),
+        _state(0),
+        _method(countPixels, T_COLOR_FEATURE::PixelSize, T_COLOR_FEATURE::SettingsSize, s)
+    {
+    }
+
     ~NeoPixelBus()
     {
     }

--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -84,10 +84,10 @@ public:
     {
     }
 
-    NeoPixelBus(uint16_t countPixels, Stream *s) :
+    NeoPixelBus(uint16_t countPixels, Stream* pixieStream) :
         _countPixels(countPixels),
         _state(0),
-        _method(countPixels, T_COLOR_FEATURE::PixelSize, T_COLOR_FEATURE::SettingsSize, s)
+        _method(countPixels, T_COLOR_FEATURE::PixelSize, T_COLOR_FEATURE::SettingsSize, pixieStream)
     {
     }
 

--- a/src/NeoPixelBusLg.h
+++ b/src/NeoPixelBusLg.h
@@ -133,6 +133,12 @@ public:
     {
     }
 
+     NeoPixelBusLg(uint16_t countPixels, Stream* pixieStream) :
+        NeoPixelBus<T_COLOR_FEATURE, T_METHOD>(countPixels, pixieStream),
+        Shader()
+    {
+    }
+
     ~NeoPixelBusLg()
     {
     }

--- a/src/internal/NeoMethods.h
+++ b/src/internal/NeoMethods.h
@@ -37,6 +37,10 @@ License along with NeoPixel.  If not, see
 #include "methods/Sm16716GenericMethod.h"
 #include "methods/Mbi6033GenericMethod.h"
 
+//Adafruit Pixie via UART, not platform specific
+//
+#include "methods/PixieSerialMethod.h"
+
 // Platform specific and One Wire (data) methods
 //
 #if defined(ARDUINO_ARCH_ESP8266)

--- a/src/internal/NeoMethods.h
+++ b/src/internal/NeoMethods.h
@@ -39,7 +39,7 @@ License along with NeoPixel.  If not, see
 
 //Adafruit Pixie via UART, not platform specific
 //
-#include "methods/PixieSerialMethod.h"
+#include "methods/PixieStreamMethod.h"
 
 // Platform specific and One Wire (data) methods
 //

--- a/src/internal/methods/PixieSerialMethod.h
+++ b/src/internal/methods/PixieSerialMethod.h
@@ -1,0 +1,99 @@
+/*-------------------------------------------------------------------------
+NeoPixel library helper functions for DotStars using general Pins (APA102).
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/NeoPixelBus)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/NeoPixelBus library.
+
+NeoPixelBus is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+NeoPixelBus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with NeoPixel.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+/*
+  Pixie reads data in at 115.2k serial, 8N1.
+  Byte order is R1, G1, B1, R2, G2, B2, ... where the first triplet is the
+  color of the LED that's closest to the controller. 1ms of silence triggers
+  latch. 2 seconds silence (or overheating) triggers LED off (for safety).
+*/
+
+
+#pragma once
+
+
+class PixieSerialMethod
+{
+public:
+    typedef NeoNoSettings SettingsObject;
+
+    PixieSerialMethod(uint16_t pixelCount, size_t elementSize, size_t settingsSize, Stream *s) :
+        _sizeData(pixelCount * elementSize + settingsSize),
+        _endTime(0),
+        _stream(s)
+    {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        // data cleared later in Begin()
+    }
+
+    ~PixieSerialMethod()
+    {
+        free(_data);
+    }
+
+    bool IsReadyToUpdate() const
+    {
+        return (micros() - _endTime) > 1000L; // ensure 1ms delay between calls
+    }
+
+    void Initialize()
+    {
+        //nothing to initialize, UART is managed outside this library
+    }
+
+    void Update(bool)
+    {
+        _stream->write(_data, _sizeData);
+        _endTime = micros(); // Save time to ensure 1ms delay
+    }
+
+    bool AlwaysUpdate()
+    {
+        //Pixie expects to receive data every <2 seconds
+        return true;
+    }
+
+    uint8_t* getData() const
+    {
+        return _data;
+    };
+
+    size_t getDataSize() const
+    {
+        return _sizeData;
+    };
+
+    void applySettings([[maybe_unused]] const SettingsObject& settings)
+    {
+    }
+
+private:
+    const size_t   _sizeData;   // Size of '_data' buffer below
+
+    uint8_t* _data;       // Holds LED color values
+    Stream *_stream;
+    uint32_t _endTime;
+};


### PR DESCRIPTION
Added support for Adafruit's Pixie product.  

Product page: https://www.adafruit.com/product/2741
Original Library: https://github.com/adafruit/Adafruit_Pixie/tree/master

Simple protocol over UART:
Pixie reads data in at 115.2k serial, 8N1.  Byte order is R1, G1, B1, R2, G2, B2, ... where the first triplet is the color of the LED that's closest to the controller. 1ms of silence triggers latch. 2 seconds silence (or overheating) triggers LED off (for safety).

I left the setup and management of the UART out of the library to help ensure compatibility across all boards.