### PR TITLE
PixieStream - Add stream flush to destructor

### DIFF
--- a/src/internal/methods/PixieStreamMethod.h
+++ b/src/internal/methods/PixieStreamMethod.h
@@ -51,6 +51,7 @@ public:
 
     ~PixieStreamMethod()
     {
+        _stream->flush();
         free(_data);
     }
 


### PR DESCRIPTION
Added a stream flush to the Pixie destructor.  

(Thanks for cleaning up the initializer list, originally was going to include that in this PR as well)