### PR TITLE
Fix for API Change

### DIFF
--- a/src/internal/methods/NeoEsp32I2sMethod.h
+++ b/src/internal/methods/NeoEsp32I2sMethod.h
@@ -171,7 +171,7 @@ public:
 
         i2sDeinit(_bus.I2sBusNumber);
 
-        gpio_matrix_out(_pin, 0x100, false, false);
+        gpio_matrix_out(_pin, SIG_GPIO_OUT_IDX, false, false);
         pinMode(_pin, INPUT);
 
         free(_data);

--- a/src/internal/methods/NeoEsp32I2sXMethod.h
+++ b/src/internal/methods/NeoEsp32I2sXMethod.h
@@ -453,7 +453,7 @@ public:
         }
 
         // disconnect muxed pin
-        gpio_matrix_out(pin, 0x100, false, false);
+        gpio_matrix_out(pin, SIG_GPIO_OUT_IDX, false, false);
         pinMode(pin, INPUT);
 
         _muxId = s_context.MuxMap.InvalidMuxId;

--- a/src/internal/methods/NeoEsp32RmtMethod.h
+++ b/src/internal/methods/NeoEsp32RmtMethod.h
@@ -556,7 +556,7 @@ public:
 
         ESP_ERROR_CHECK(rmt_driver_uninstall(_channel.RmtChannelNumber));
 
-        gpio_matrix_out(_pin, 0x100, false, false);
+        gpio_matrix_out(_pin, SIG_GPIO_OUT_IDX, false, false);
         pinMode(_pin, INPUT);
 
         free(_dataEditing);


### PR DESCRIPTION
Used to state just use 0x100, but this is incorrect on some platforms.  Recommened now to just use SIG_GPIO_OUT_IDX.