### PR TITLE
Fixed and improved HtmlColor::ToNumericalString

### DIFF
--- a/src/internal/colors/HtmlColor.cpp
+++ b/src/internal/colors/HtmlColor.cpp
@@ -36,28 +36,29 @@ static inline char hexdigit(uint8_t v)
 }
 
 
-size_t HtmlColor::ToNumericalString(char* buf, size_t bufSize) const
-{
-    size_t bufLen = bufSize - 1;
+/**
+ * Generates a Html encoded hex color string (#aabbcc) with null termination.
+ *
+ * @param buf the buffer to write the string to
+ * @param bufSize the maximum buffer size (8 recommended for # + 123456 + null terminator)
+ * @return The amount of chars written to buf.
+ */
+size_t HtmlColor::ToNumericalString(char *buf, size_t bufSize) const {
+  if (bufSize > 0) {
+    buf[0] = '#';
 
-    if (bufLen-- > 0)
-    {
-        if (bufLen > 0)
-        {
-            buf[0] = '#';
-        }
-
-        uint32_t color = Color;
-        for (uint8_t indexDigit = 6; indexDigit > 0; indexDigit--)
-        {
-            if (bufLen > indexDigit)
-            {
-                buf[indexDigit] = hexdigit(color & 0x0000000f);
-            }
-            color >>= 4;
-        }
-
-        buf[(bufLen < 7 ? bufLen : 7)] = 0;
+    uint32_t color = Color;
+    for (uint8_t indexDigit = 6; indexDigit > 0; --indexDigit) {
+      if (bufSize > indexDigit) {
+        buf[indexDigit] = hexdigit(color & 0x0000000f);
+      }
+      color >>= 4;
     }
-    return 7;
+
+    size_t lastIndex = (bufSize < 7 ? bufSize - 1 : 7);
+    buf[lastIndex] = 0;
+
+    return lastIndex+1;
+  }
+  return 0;
 }


### PR DESCRIPTION
The method didn't work correctly as it decremented bufLen twice and forgot one digit. Besides this, it always returned 7 instead of the actual amount of characters used.

`# + 123456 + null termination = 8 chars`

You can try it on your desktop computer with that code and a C++ compiler:

```cpp
#include <iostream>
#include <cstdint>

class HtmlColor {
public:
    HtmlColor(uint32_t color) : Color(color) {}

    size_t ToNumericalStringOrig(char *buf, size_t bufSize) const;
    size_t ToNumericalString(char *buf, size_t bufSize) const;

private:
    uint32_t Color;
};

static inline char hexdigit(uint8_t v) {
  return v + (v < 10 ? '0' : 'a' - 10);
}

size_t HtmlColor::ToNumericalStringOrig(char* buf, size_t bufSize) const
{
  size_t bufLen = bufSize - 1;

  if (bufLen-- > 0)
  {
    if (bufLen > 0)
    {
      buf[0] = '#';
    }

    uint32_t color = Color;
    for (uint8_t indexDigit = 6; indexDigit > 0; indexDigit--)
    {
      if (bufLen > indexDigit)
      {
        buf[indexDigit] = hexdigit(color & 0x0000000f);
      }
      color >>= 4;
    }

    buf[(bufLen < 7 ? bufLen : 7)] = 0;
  }
  return 7;
}


/**
 * Generates a Html encoded hex color string (#aabbcc) with null termination.
 *
 * @param buf the buffer to write the string to
 * @param bufSize the maximum buffer size (8 recommended for # + 123456 + null terminator)
 * @return The amount of chars written to buf.
 */
size_t HtmlColor::ToNumericalString(char *buf, size_t bufSize) const {
  if (bufSize > 0) {
    buf[0] = '#';

    uint32_t color = Color;
    for (uint8_t indexDigit = 6; indexDigit > 0; --indexDigit) {
      if (bufSize > indexDigit) {
        buf[indexDigit] = hexdigit(color & 0x0000000f);
      }
      color >>= 4;
    }

    size_t lastIndex = (bufSize < 7 ? bufSize - 1 : 7);
    buf[lastIndex] = 0;

    return lastIndex+1;
  }
  return 0;
}


int main() {
  char string[8]; // # + 123456 + null terminator = 8

  HtmlColor color(0xaabbcc);

  size_t len;

  len = color.ToNumericalStringOrig(string, 8);
  std::cout << "Original result:" << std::endl << string << std::endl << len << std::endl;

  len = color.ToNumericalString(string, 8);
  std::cout << "New result:" << std::endl << string << std::endl << len << std::endl;

  return 0;
}
```

Output:

```text
Original result:
#aabbc
7
New result:
#aabbcc
8
```