### PR TITLE
Update WS2812X ESP32 RMT timing for WS2815 compat

### DIFF
--- a/src/internal/methods/NeoEsp32RmtMethod.h
+++ b/src/internal/methods/NeoEsp32RmtMethod.h
@@ -313,8 +313,8 @@ public:
 class NeoEsp32RmtInvertedSpeedWs2812x : public NeoEsp32RmtInvertedSpeedBase
 {
 public:
-    const static DRAM_ATTR uint32_t RmtBit0 = Item32Val(400, 850);
-    const static DRAM_ATTR uint32_t RmtBit1 = Item32Val(800, 450);
+    const static DRAM_ATTR uint32_t RmtBit0 = Item32Val(315, 935); // WS2812B / WS2815 compat compromise
+    const static DRAM_ATTR uint32_t RmtBit1 = Item32Val(890, 360); // WS2812B / WS2815 compat compromise
     const static DRAM_ATTR uint16_t RmtDurationReset = FromNs(300000); // 300us
 
     static void IRAM_ATTR Translate(const void* src,


### PR DESCRIPTION
### Context

I'm using WLED and have been trying to troubleshoot flickering issues for a while now with my WS2815 LED strips from BTF-Lighting. I have about 6 metres of cable between my controller and each strip, and have taken the following measures so far:
- Added a 74AHCT125 level shifter
- Connected 5V supply directly to 5V pin on my ESP32 dev board (avoids voltage drop across input protection diode on MicroUSB input?)
- Add 110Ω / 220Ω series resistors in series with each output from the level shifter. The resistors are individually matched to each output using an oscilloscope.

![IMG_0180 Large](https://github.com/Makuna/NeoPixelBus/assets/23110282/ef10a0d3-35f9-4421-a8c8-3f7210a76b6c)


These efforts cleaned up the data signal and reduced flickering considerably, but it never went away until I upgraded to WLED 0.15 beta. This finally fixed the flickering for one of my two LED strips! A bit more investigation showed that WLED changed to I2S by default for the first output, which has different timing to RMT. And reading the WS2815 datasheet showed that the RMT timing for WS2812B is out of the specs for WS2812.


### Commit Summary

The existing values are out of spec for WS2815 which results in flickering, especially on longer cable runs.

These new RMT values are still closer to ideal WS2812B specs than the current I2S WS2812X timing (about 310us / 940us).

Datasheet specs:
|                         | T0H     | T1H       | T0L      | T1L     |
| ----------------------- | ------- | --------- | -------- | ------- |
| WS2812B                 | 250-550 | 650-950   | 700-1000 | 300-600 |
| WS2815                  | 220-380 | 580-1600  | 580-1600 | 220-420 |


### Note for ESP32 WLED users interested in this PR
To resolve flickering issues in the meantime, upgrade to WLED 0.15 beta. For more than 1 output, this also adds APA106 support which uses compatible timings with WS2815 on the second output.

| WLED 0.15 with WS2815 LED | Mode WS281X | Mode APA106 |
| ------------------------- | ----------- | ----------- |
| Output 1 (I2S)            | Good        | Bad         |
| Output 2+ (RMT)           | Bad         | Good        |

