### PR TITLE
Fix incorrect syntax for unlikely annotation.

### DIFF
--- a/src/internal/NeoUtil.h
+++ b/src/internal/NeoUtil.h
@@ -28,21 +28,23 @@ License along with NeoPixel.  If not, see
 
 #ifdef ARDUINO_ARCH_ESP32
 #if defined NDEBUG || defined CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT
-#define ESP_ERROR_CHECK_WITHOUT_ABORT_SILENT_TIMEOUT(x) ({                                         \
-        esp_err_t err_rc_ = (x);                                                    \
-        err_rc_;                                                                    \
-    })
+#define ESP_ERROR_CHECK_WITHOUT_ABORT_SILENT_TIMEOUT(x) \
+  ({                                                    \
+    esp_err_t err_rc_ = (x);                            \
+    err_rc_;                                            \
+  })
 #else
-#define ESP_ERROR_CHECK_WITHOUT_ABORT_SILENT_TIMEOUT(x) ({                                         \
-        esp_err_t err_rc_ = (x);                                                    \
-        if (unlikely(err_rc_ != ESP_OK && err_rc_ != ESP_ERR_TIMEOUT)) {                                          \
-            _esp_error_check_failed_without_abort(err_rc_, __FILE__, __LINE__,      \
-                                                  __ASSERT_FUNC, #x);               \
-        }                                                                           \
-        err_rc_;                                                                    \
-    })
-#endif // NDEBUG
-#endif // ARDUINO_ARCH_ESP32
+#define ESP_ERROR_CHECK_WITHOUT_ABORT_SILENT_TIMEOUT(x)                  \
+  ({                                                                     \
+    esp_err_t err_rc_ = (x);                                             \
+    if (err_rc_ != ESP_OK && err_rc_ != ESP_ERR_TIMEOUT) [[unlikely]] {  \
+      _esp_error_check_failed_without_abort(err_rc_, __FILE__, __LINE__, \
+                                            __ASSERT_FUNC, #x);          \
+    }                                                                    \
+    err_rc_;                                                             \
+  })
+#endif  // NDEBUG
+#endif  // ARDUINO_ARCH_ESP32
 
 // some platforms do not come with STL or properly defined one, specifically functional
 // if you see...


### PR DESCRIPTION
I'm not sure what this unlikely syntax was, but it didn't compile, at least for me. I switched it to using the `[[unlikely]]` annotation the way it's supposed to be added for an unlikely conditional branch.

I also reformatted this macro, since the line continuations were all off.
