### PR TITLE
Hd108 bare minimal for me

### DIFF
--- a/examples/Hd108Test/Hd108Test.ino
+++ b/examples/Hd108Test/Hd108Test.ino
@@ -1,0 +1,84 @@
+// DotStarTest
+// This example will cycle between showing four pixels as Red, Green, Blue, White
+// and then showing those pixels as Black.
+//
+// There is serial output of the current state so you can confirm and follow along
+//
+
+#include <NeoPixelBus.h>
+
+const uint16_t PixelCount = 4; // this example assumes 4 pixels, making it smaller will cause a failure
+
+// make sure to set this to the correct pins
+const uint8_t DotClockPin = 9;
+const uint8_t DotDataPin = 8;  
+
+uint16_t colorSaturation=32768;
+
+// for software bit bang, with Rgb48Color
+NeoPixelBus<Hd108RgbFeature, Hd108Method> strip(PixelCount, DotClockPin, DotDataPin);
+
+// for hardware SPI (best performance but must use hardware pins)
+//NeoPixelBus<Hd108RgbFeature, Hd108SpiMethod> strip(PixelCount);
+
+// Rgbw64Color implementation
+// NeoPixelBus<Hd108LrgbFeature, DotStarMethod> strip(PixelCount, DotClockPin, DotDataPin);
+
+Rgb48Color red(colorSaturation, 0, 0);
+Rgb48Color green(0, colorSaturation, 0);
+Rgb48Color blue(0, 0, colorSaturation);
+Rgb48Color white(colorSaturation);
+Rgb48Color black(0);
+
+// for use with RGB DotStars when using the luminance/brightness global value
+// note that its range is only 0 - 31 (31 is full bright) and 
+// also note that it is not useful for POV displays as it will cause more flicker
+Rgbw64Color redL(colorSaturation, 0, 0, 31); // use white value to store luminance
+Rgbw64Color greenL(0, colorSaturation, 0, 31); // use white value to store luminance
+Rgbw64Color blueL(0, 0, colorSaturation, 31); // use white value to store luminance
+Rgbw64Color whiteL(colorSaturation, colorSaturation, colorSaturation, colorSaturation / 8); // luminance is only 0-31
+
+void setup()
+{
+    Serial.begin(115200);
+    while (!Serial); // wait for serial attach
+
+    Serial.println();
+    Serial.println("Initializing...");
+    Serial.flush();
+
+    // this resets all the neopixels to an off state
+    strip.Begin();
+    strip.ClearTo(black);
+    strip.Show();
+
+    Serial.println();
+    Serial.println("Running...");
+}
+
+void loop()
+{
+    delay(5000);
+
+    Serial.println("Colors R, G, B, W...");
+
+    // set the colors, 
+    strip.SetPixelColor(0, red);
+    strip.SetPixelColor(1, green);
+    strip.SetPixelColor(2, blue);
+    strip.SetPixelColor(3, white);
+    strip.Show();
+
+
+    delay(5000);
+
+    Serial.println("Off ...");
+
+    // turn off the pixels
+    strip.SetPixelColor(0, black);
+    strip.SetPixelColor(1, black);
+    strip.SetPixelColor(2, black);
+    strip.SetPixelColor(3, black);
+    strip.Show();
+
+}

--- a/src/internal/features/DotStarLrgbFeatures.h
+++ b/src/internal/features/DotStarLrgbFeatures.h
@@ -73,4 +73,11 @@ class DotStarLbgr64Feature :
 {
 };
 
+class DotStarLrgb64Feature :
+    public DotStarL4WordFeature<ColorIndexR, ColorIndexG, ColorIndexB>,
+    public NeoElementsNoSettings
+{
+};
+
 typedef DotStarLbgr64Feature Hd108LbgrFeature;
+typedef DotStarLrgb64Feature Hd108LrgbFeature;

--- a/src/internal/features/DotStarRgbFeatures.h
+++ b/src/internal/features/DotStarRgbFeatures.h
@@ -74,4 +74,11 @@ class DotStarBgr48Feature :
 {
 };
 
+class DotStarRgb48Feature :
+    public DotStarX4WordFeature<ColorIndexR, ColorIndexG, ColorIndexB>,
+    public NeoElementsNoSettings
+{
+};
+
 typedef DotStarBgr48Feature Hd108BgrFeature;
+typedef DotStarRgb48Feature Hd108RgbFeature;

--- a/src/internal/methods/Hd108GenericMethod.h
+++ b/src/internal/methods/Hd108GenericMethod.h
@@ -78,7 +78,7 @@ public:
 
     void Update(bool)
     {
-        const uint8_t startFrame[4] = { 0x00 };
+        const uint8_t startFrame[16] = { 0x00 };
         const uint8_t endFrame[4] = { 0xff };
         
         _wire.beginTransaction();


### PR DESCRIPTION
Here are few little changes and working example for Hd108. 
Solution currently in master does not header the frame properly as defined in the spec. (very confusing) datasheets try to define 128bits to be found at the beginning of the frame, which is definitely required. 
Datasheet also clearly defines to implement 1bit per led "of 1's" at the end of the frame, I've never needed this for some reason.

Also, my strips are in RGB color order, I'm not certain whether all Hd108's are. I'm not certain whether I implemented these correctly but "works for me")

Makuna, your work is greatly appreciated and big thanks for maintaining this!) 
 