### PR TITLE
Fixes for CORE3 from WLED

### DIFF
--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -330,15 +330,15 @@ public:
     void SetPixelSettings(const typename T_COLOR_FEATURE::SettingsObject& settings)
     {
         T_COLOR_FEATURE::applySettings(_method.getData(), _method.getDataSize(), settings);
-        if (_method.SwapBuffers())
-        {
-            // some methods have two internal buffers
-            // so need to swap so settings are stored in both copies
-            //
-            T_COLOR_FEATURE::applySettings(_method.getData(), _method.getDataSize(), settings);
-            // swap back to minimize inconsistencies
-            _method.SwapBuffers();
-        }
+        // if (_method.SwapBuffers())
+        // {
+        //     // some methods have two internal buffers
+        //     // so need to swap so settings are stored in both copies
+        //     //
+        //     T_COLOR_FEATURE::applySettings(_method.getData(), _method.getDataSize(), settings);
+        //     // swap back to minimize inconsistencies
+        //     _method.SwapBuffers();
+        // }
         Dirty();
     };
 

--- a/src/internal/methods/ESP/ESP32/NeoEsp32RmtXMethod.h
+++ b/src/internal/methods/ESP/ESP32/NeoEsp32RmtXMethod.h
@@ -76,6 +76,7 @@ public:
         // wait until the last send finishes before destructing everything
         // arbitrary time out of 10 seconds
 
+        ESP_ERROR_CHECK(rmt_disable(_channel)); // TroyHacks: added to disable the channel before deleting it
         ESP_ERROR_CHECK_WITHOUT_ABORT(rmt_tx_wait_all_done(_channel, 10000 / portTICK_PERIOD_MS));
         ESP_ERROR_CHECK(rmt_del_channel(_channel));
 


### PR DESCRIPTION
Well, one fix, one feature I just commented out. 

```ESP_ERROR_CHECK(rmt_disable(_channel));``` seems to be required (in WLED  at least) to re-init the busses without fatal errors. 

And ```_method.SwapBuffers()``` just doesn't seem to exist yet in CORE3. had to comment out to compile.