### PR TITLE
Esp32c6/Esp32h2 bitbang method

### DIFF
--- a/src/internal/methods/NeoEspBitBangMethod.cpp
+++ b/src/internal/methods/NeoEspBitBangMethod.cpp
@@ -120,7 +120,7 @@ bool IRAM_ATTR neoEspBitBangWriteSpacingPixels(const uint8_t* pixels,
         setRegister = &GPIO.out_w1ts.val;
         clearRegister = &GPIO.out_w1tc.val;
     }
-#if !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6) && !defined(CONFIG_IDF_TARGET_ESP32H2)
     else
     {
         setRegister = &GPIO.out1_w1ts.val;


### PR DESCRIPTION
Hello,

My build was failing for C6 and H2, as `out1_w1ts` not defined.

Just noting here for anyone googling;  The _vanilla_ Adafruit Neopixel library doesn't currently work on the Seeed Studio Xiao ESP32-C6, but (with this PR) NeoPixelBus does!

@Makuna appreciate pain of multiple RMT implementations ... but I spotted this https://github.com/will-rigby/ESP32-C6-WS2812B  and would love a non-BB method.  I see you're documenting thoughts/future-work as issues, but would you please opine; what do you see as being the best/preferred non-BB for C6/H2?

Thank you