### PR TITLE
Use calloc to clear transmit buffers upon allocation

### DIFF
--- a/src/internal/methods/NeoEsp32RmtMethod.h
+++ b/src/internal/methods/NeoEsp32RmtMethod.h
@@ -683,7 +683,7 @@ private:
 
     void construct()
     {
-        _dataEditing = static_cast<uint8_t*>(malloc(_sizeData));
+        _dataEditing = static_cast<uint8_t*>(calloc(_sizeData, 1));
         // data cleared later in Begin()
 
         _dataSending = static_cast<uint8_t*>(calloc(_sizeData, 1));

--- a/src/internal/methods/NeoEsp8266UartMethod.h
+++ b/src/internal/methods/NeoEsp8266UartMethod.h
@@ -148,7 +148,7 @@ protected:
     NeoEsp8266UartBase(uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
         _sizeData(pixelCount * elementSize + settingsSize)
     {
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        _data = static_cast<uint8_t*>(calloc(_sizeData, 1));
         // data cleared later in Begin()
     }
 

--- a/src/internal/methods/Rp2040/NeoRp2040x4Method.h
+++ b/src/internal/methods/Rp2040/NeoRp2040x4Method.h
@@ -310,7 +310,7 @@ private:
 
     void construct()
     {
-        _dataEditing = static_cast<uint8_t*>(malloc(_sizeData));
+        _dataEditing = static_cast<uint8_t*>(calloc(_sizeData, 1));
         // data cleared later in Begin() with a ClearTo(0)
 
         _dataSending = static_cast<uint8_t*>(calloc(_sizeData, 1));


### PR DESCRIPTION
RMT, RP2040x4 and 8266AsyncUart methods covered.
However I have also made 8322fcebf8d92ede58bccfe223ecf7a040ad810d if that would be a better fit.

Resolves #904 