### PR TITLE
Memory management rework

### DIFF
--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -29,8 +29,18 @@ License along with NeoPixel.  If not, see
 
 // standard neo definitions
 // 
-const uint8_t NEO_DIRTY = 0x80; // a change was made to pixel data that requires a show
-const uint16_t PixelIndex_OutOfBounds = 0xffff;
+constexpr uint8_t NEO_VALID = 0x01; // bus is valid
+constexpr uint8_t NEO_DIRTY = 0x80; // a change was made to pixel data that requires a show
+constexpr uint16_t PixelIndex_OutOfBounds = 0xffff;
+
+typedef union {
+    uint8_t     flags;
+    struct {
+        bool    valid    : 1;   // LSB
+        uint8_t reserved : 6;
+        bool    dirty    : 1;   // MSB
+    };
+} neo_flags_t;
 
 #include "internal/NeoUtil.h"
 #include "internal/animations/NeoEase.h"
@@ -101,36 +111,72 @@ public:
         return NeoBufferContext<T_COLOR_FEATURE>(_pixels(), PixelsSize());
     }
 
-    void Begin()
+    bool Begin()
     {
-        _method.Initialize();
+        if (!_method.Initialize())
+        {
+            return false;
+        }
+        _state |= NEO_VALID;
         ClearTo(0);
+        if (_method.SwapBuffers())
+        {
+            ClearTo(0); // double buffer, clear again
+        }
+        return true;
     }
 
     // used by DotStarSpiMethod/DotStarEsp32DmaSpiMethod if pins can be configured
-    void Begin(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    bool Begin(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     {
-        _method.Initialize(sck, miso, mosi, ss);
+        if (!_method.Initialize(sck, miso, mosi, ss))
+        {
+            return false;
+        }
+        _state |= NEO_VALID;
         ClearTo(0);
+        if (_method.SwapBuffers())
+        {
+            ClearTo(0); // double buffer, clear again
+        }
+        return true;
     }
 
     // used by DotStarEsp32DmaSpiMethod if pins can be configured - reordered and extended version supporting quad SPI
-    void Begin(int8_t sck, int8_t dat0, int8_t dat1, int8_t dat2, int8_t dat3, int8_t ss)
+    bool Begin(int8_t sck, int8_t dat0, int8_t dat1, int8_t dat2, int8_t dat3, int8_t ss)
     {
-        _method.Initialize(sck, dat0, dat1, dat2, dat3, ss);
+        if (!_method.Initialize(sck, dat0, dat1, dat2, dat3, ss))
+        {
+            return false;
+        }
+        _state |= NEO_VALID;
         ClearTo(0);
+        if (_method.SwapBuffers())
+        {
+            ClearTo(0); // double buffer, clear again
+        }
+        return true;
     }
 
     // used by DotStarEsp32DmaSpiMethod if pins can be configured - reordered and extended version supporting oct SPI
-    void Begin(int8_t sck, int8_t dat0, int8_t dat1, int8_t dat2, int8_t dat3, int8_t dat4, int8_t dat5, int8_t dat6, int8_t dat7, int8_t ss)
+    bool Begin(int8_t sck, int8_t dat0, int8_t dat1, int8_t dat2, int8_t dat3, int8_t dat4, int8_t dat5, int8_t dat6, int8_t dat7, int8_t ss)
     {
-        _method.Initialize(sck, dat0, dat1, dat2, dat3, dat4, dat5, dat6, dat7, ss);
+        if (!_method.Initialize(sck, dat0, dat1, dat2, dat3, dat4, dat5, dat6, dat7, ss))
+        {
+            return false;
+        }
+        _state |= NEO_VALID;
         ClearTo(0);
+        if (_method.SwapBuffers())
+        {
+            ClearTo(0); // double buffer, clear again
+        }
+        return true;
     }
 
     void Show(bool maintainBufferConsistency = true)
     {
-        if (!IsDirty() && !_method.AlwaysUpdate())
+        if (!IsValid() || (!IsDirty() && !_method.AlwaysUpdate()))
         {
             return;
         }
@@ -142,8 +188,13 @@ public:
 
     inline bool CanShow() const
     { 
-        return _method.IsReadyToUpdate();
+        return IsValid() && _method.IsReadyToUpdate();
     };
+
+    bool IsValid() const
+    {
+        return (_state & NEO_VALID);
+    }
 
     bool IsDirty() const
     {
@@ -160,13 +211,25 @@ public:
         _state &= ~NEO_DIRTY;
     };
 
+    size_t MemorySize() const
+    {
+        return _method.MemorySize();
+    };
+
+    static size_t MemorySize(size_t countPixels)
+    {
+        return T_METHOD::MemorySize(countPixels, T_COLOR_FEATURE::PixelSize, T_COLOR_FEATURE::SettingsSize) + sizeof(NeoPixelBus<T_COLOR_FEATURE,T_METHOD>);
+    };
+
     uint8_t* Pixels() 
     {
+        if (!IsValid()) return nullptr;
         return _pixels();
     };
 
     size_t PixelsSize() const
     {
+        if (!IsValid()) return 0;
         return _method.getDataSize() - T_COLOR_FEATURE::SettingsSize;
     };
 
@@ -182,7 +245,7 @@ public:
 
     void SetPixelColor(uint16_t indexPixel, typename T_COLOR_FEATURE::ColorObject color)
     {
-        if (indexPixel < _countPixels)
+        if (IsValid() && indexPixel < _countPixels)
         {
             T_COLOR_FEATURE::applyPixelColor(_pixels(), indexPixel, color);
             Dirty();
@@ -191,7 +254,7 @@ public:
 
     typename T_COLOR_FEATURE::ColorObject GetPixelColor(uint16_t indexPixel) const
     {
-        if (indexPixel < _countPixels)
+        if (IsValid() && indexPixel < _countPixels)
         {
             return T_COLOR_FEATURE::retrievePixelColor(_pixels(), indexPixel);
         }
@@ -210,6 +273,8 @@ public:
 
     void ClearTo(typename T_COLOR_FEATURE::ColorObject color)
     {
+        if (!IsValid()) return;
+
         uint8_t temp[T_COLOR_FEATURE::PixelSize]; 
         uint8_t* pixels = _pixels();
 
@@ -222,6 +287,8 @@ public:
 
     void ClearTo(typename T_COLOR_FEATURE::ColorObject color, uint16_t first, uint16_t last)
     {
+        if (!IsValid()) return;
+
         if (first < _countPixels &&
             last < _countPixels &&
             first <= last)
@@ -240,6 +307,8 @@ public:
 
     void RotateLeft(uint16_t rotationCount)
     {
+        if (!IsValid()) return;
+
         if ((_countPixels - 1) >= rotationCount)
         {
             _rotateLeft(rotationCount, 0, _countPixels - 1);
@@ -248,6 +317,8 @@ public:
 
     void RotateLeft(uint16_t rotationCount, uint16_t first, uint16_t last)
     {
+        if (!IsValid()) return;
+
         if (first < _countPixels &&
             last < _countPixels &&
             first < last &&
@@ -259,6 +330,8 @@ public:
 
     void ShiftLeft(uint16_t shiftCount)
     {
+        if (!IsValid()) return;
+
         if ((_countPixels - 1) >= shiftCount)
         {
             _shiftLeft(shiftCount, 0, _countPixels - 1);
@@ -268,6 +341,8 @@ public:
 
     void ShiftLeft(uint16_t shiftCount, uint16_t first, uint16_t last)
     {
+        if (!IsValid()) return;
+
         if (first < _countPixels && 
             last < _countPixels && 
             first < last &&
@@ -280,6 +355,8 @@ public:
 
     void RotateRight(uint16_t rotationCount)
     {
+        if (!IsValid()) return;
+
         if ((_countPixels - 1) >= rotationCount)
         {
             _rotateRight(rotationCount, 0, _countPixels - 1);
@@ -288,6 +365,8 @@ public:
 
     void RotateRight(uint16_t rotationCount, uint16_t first, uint16_t last)
     {
+        if (!IsValid()) return;
+
         if (first < _countPixels &&
             last < _countPixels &&
             first < last &&
@@ -299,6 +378,8 @@ public:
 
     void ShiftRight(uint16_t shiftCount)
     {
+        if (!IsValid()) return;
+
         if ((_countPixels - 1) >= shiftCount)
         {
             _shiftRight(shiftCount, 0, _countPixels - 1);
@@ -308,6 +389,8 @@ public:
 
     void ShiftRight(uint16_t shiftCount, uint16_t first, uint16_t last)
     {
+        if (!IsValid()) return;
+
         if (first < _countPixels &&
             last < _countPixels &&
             first < last &&
@@ -320,6 +403,8 @@ public:
     
     void SwapPixelColor(uint16_t indexPixelOne, uint16_t indexPixelTwo)
     {
+        if (!IsValid()) return;
+
         auto colorOne = GetPixelColor(indexPixelOne);
         auto colorTwo = GetPixelColor(indexPixelTwo);
 
@@ -329,6 +414,8 @@ public:
 
     void SetPixelSettings(const typename T_COLOR_FEATURE::SettingsObject& settings)
     {
+        if (!IsValid()) return;
+
         T_COLOR_FEATURE::applySettings(_method.getData(), _method.getDataSize(), settings);
         if (_method.SwapBuffers())
         {
@@ -344,12 +431,16 @@ public:
 
     void SetMethodSettings(const typename T_METHOD::SettingsObject& settings)
     {
+        if (!IsValid()) return;
+
         _method.applySettings(settings);
         Dirty();
     };
  
     uint32_t CalcTotalMilliAmpere(const typename T_COLOR_FEATURE::ColorObject::SettingsObject& settings)
     {
+        if (!IsValid()) return 0;
+
         uint32_t total = 0; // in 1/10th milliamps
 
         for (uint16_t index = 0; index < _countPixels; index++)
@@ -364,7 +455,7 @@ public:
 protected:
     const uint16_t _countPixels; // Number of RGB LEDs in strip
 
-    uint8_t _state;     // internal state
+    uint8_t _state;     // internal state (should use neo_flags_t for clarity)
     T_METHOD _method;
 
     uint8_t* _pixels()

--- a/src/internal/buffers/NeoBufferMethods.h
+++ b/src/internal/buffers/NeoBufferMethods.h
@@ -140,6 +140,18 @@ public:
         T_COLOR_FEATURE::movePixelsInc(pPixelDest, pPixelSrc, count);
     }
 
+    size_t MemorySize() const
+    {
+        size_t dataSize = PixelsSize();
+        return dataSize + sizeof(NeoBufferMethod<T_COLOR_FEATURE>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(NeoBufferMethod<T_COLOR_FEATURE>);
+    };
+
     typedef typename T_COLOR_FEATURE::ColorObject ColorObject;
     typedef T_COLOR_FEATURE ColorFeature;
 

--- a/src/internal/buffers/NeoDib.h
+++ b/src/internal/buffers/NeoDib.h
@@ -157,6 +157,18 @@ public:
         _state &= ~NEO_DIRTY;
     };
 
+    size_t MemorySize() const
+    {
+        size_t dataSize = PixelsSize();
+        return dataSize + sizeof(NeoDib<T_COLOR_OBJECT>);
+    };
+
+    size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(NeoDib<T_COLOR_OBJECT>);
+    };
+
 private:
     const uint16_t _countPixels; // Number of RGB LEDs in strip
     T_COLOR_OBJECT* _pixels;

--- a/src/internal/methods/DotStarEsp32DmaSpiMethod.h
+++ b/src/internal/methods/DotStarEsp32DmaSpiMethod.h
@@ -50,11 +50,6 @@ public:
         {
             _spiBufferSize += 4 - alignment;
         }
-
-        _data = static_cast<uint8_t*>(malloc(_spiBufferSize));
-        _dmadata = static_cast<uint8_t*>(heap_caps_malloc(_spiBufferSize, MALLOC_CAP_DMA));
-
-        // data cleared later in NeoPixelBus::Begin()
     }
 
     // Support constructor specifying pins by ignoring pins
@@ -88,8 +83,22 @@ public:
         return (ret == ESP_OK || (ret == ESP_ERR_TIMEOUT && 0 == _spiTransaction.length));
     }
 
-    void Initialize(int8_t sck, int8_t dat0, int8_t dat1, int8_t dat2, int8_t dat3, int8_t dat4, int8_t dat5, int8_t dat6, int8_t dat7, int8_t ss)
+    bool Initialize(int8_t sck, int8_t dat0, int8_t dat1, int8_t dat2, int8_t dat3, int8_t dat4, int8_t dat5, int8_t dat6, int8_t dat7, int8_t ss)
     {
+        _data = static_cast<uint8_t*>(malloc(_spiBufferSize));
+        if (!_data)
+        {
+            return false;
+        }
+        _dmadata = static_cast<uint8_t*>(heap_caps_malloc(_spiBufferSize, MALLOC_CAP_DMA));
+        if (!_dmadata)
+        {
+            free(_data);
+            _data = nullptr;
+            return false;
+        }
+
+        // this is odd construct
         memset(_data, 0x00, _sizeStartFrame);
         memset(_data + _sizeStartFrame + _sizePixelData, 0x00, _spiBufferSize - (_sizeStartFrame + _sizePixelData));
 
@@ -119,32 +128,33 @@ public:
 
         _spiTransaction = { 0 };
         initSpiDevice();
+        return true;
     }
 
-    void Initialize(int8_t sck, int8_t dat0, int8_t dat1, int8_t dat2, int8_t dat3, int8_t ss)
+    bool Initialize(int8_t sck, int8_t dat0, int8_t dat1, int8_t dat2, int8_t dat3, int8_t ss)
     {
-        Initialize(sck, dat0, dat1, dat2, dat3, -1, -1, -1, -1, ss);
+        return Initialize(sck, dat0, dat1, dat2, dat3, -1, -1, -1, -1, ss);
     }
 
-    void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    bool Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     {
-        Initialize(sck, mosi, miso, -1, -1, ss);
+        return Initialize(sck, mosi, miso, -1, -1, ss);
     }
 
     // If pins aren't specified, initialize bus with just the default SCK and MOSI pins for the SPI peripheral (no SS, no >1-bit pins)
-    void Initialize()
+    bool Initialize()
     {
 #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
         if (T_SPIBUS::SpiHostDevice == VSPI_HOST)
         {
-            Initialize(SCK, -1, MOSI, -1, -1, -1);
+            return Initialize(SCK, -1, MOSI, -1, -1, -1);
         }
         else
         {
-            Initialize(14, -1, 13, -1, -1, -1);
+            return Initialize(14, -1, 13, -1, -1, -1);
         }
 #else
-        Initialize(SCK, -1, MOSI, -1, -1, -1);
+        return Initialize(SCK, -1, MOSI, -1, -1, -1);
 #endif
     }
 
@@ -201,6 +211,18 @@ public:
     size_t getDataSize() const
     {
         return _sizePixelData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _spiBufferSize;
+        return 2 * dataSize + sizeof(DotStarEsp32DmaSpiMethodBase<T_SPISPEED, T_SPIBUS>); // data and dmadata buffers plus object size
+    };
+
+    size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = (4 * T_SPIBUS::ParallelBits + pixelCount * pixelSize + settingsSize + ((pixelCount + 15) / 16 * T_SPIBUS::ParallelBits));
+        return 2 * dataSize + sizeof(DotStarEsp32DmaSpiMethodBase<T_SPISPEED, T_SPIBUS>); // data and dmadata buffers plus object size
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/DotStarGenericMethod.h
+++ b/src/internal/methods/DotStarGenericMethod.h
@@ -36,11 +36,17 @@ License along with NeoPixel.  If not, see
 
 template<typename T_TWOWIRE> class DotStarMethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef typename T_TWOWIRE::SettingsObject SettingsObject;
 
     DotStarMethodBase(uint8_t pinClock, uint8_t pinData, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _sizeEndFrame((pixelCount + 15) / 16), // 16 = div 2 (bit for every two pixels) div 8 (bits to bytes)
         _wire(pinClock, pinData)
     {
@@ -143,7 +149,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(DotStarMethodBase<T_TWOWIRE>);
     };
 

--- a/src/internal/methods/DotStarGenericMethod.h
+++ b/src/internal/methods/DotStarGenericMethod.h
@@ -44,8 +44,6 @@ public:
         _sizeEndFrame((pixelCount + 15) / 16), // 16 = div 2 (bit for every two pixels) div 8 (bits to bytes)
         _wire(pinClock, pinData)
     {
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
     }
 
 #if !defined(__AVR_ATtiny85__) && !defined(ARDUINO_attiny)
@@ -66,15 +64,27 @@ public:
     }
 
 #if defined(ARDUINO_ARCH_ESP32)
-    void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    bool Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
         _wire.begin(sck, miso, mosi, ss);
+        return true;
     }
 #endif
 
-    void Initialize()
+    bool Initialize()
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
         _wire.begin();
+        return true;
     }
 
     void Update(bool)
@@ -123,6 +133,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(DotStarMethodBase<T_TWOWIRE>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(DotStarMethodBase<T_TWOWIRE>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/Esp32_i2s.c
+++ b/src/internal/methods/Esp32_i2s.c
@@ -721,6 +721,11 @@ bool i2sWrite(uint8_t bus_num)
     return true;
 }
 
+size_t i2sGetBufferSize(uint8_t bus_num)
+{
+    return I2S[bus_num].dma_count * sizeof(lldesc_t);
+}
+
 #ifdef NEOPIXELBUS_I2S_DEBUG
 void DumpI2sPrimary(const char* label, uint32_t val)
 {

--- a/src/internal/methods/Esp32_i2s.h
+++ b/src/internal/methods/Esp32_i2s.h
@@ -56,6 +56,7 @@ void i2sSetClkWsPins(uint8_t bus_num,
     */
 bool i2sWrite(uint8_t bus_num);
 bool i2sWriteDone(uint8_t bus_num);
+size_t i2sGetBufferSize(uint8_t bus_num);
 #ifdef NEOPIXELBUS_I2S_DEBUG
 bool i2sDump(uint8_t bus_num);
 bool i2sGetClks(uint8_t bus_num, uint8_t* clkm_div_num, uint8_t* clkm_div_b, uint8_t* clkm_div_a );

--- a/src/internal/methods/Hd108GenericMethod.h
+++ b/src/internal/methods/Hd108GenericMethod.h
@@ -36,11 +36,17 @@ License along with NeoPixel.  If not, see
 
 template<typename T_TWOWIRE> class Hd108MethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef typename T_TWOWIRE::SettingsObject SettingsObject;
 
     Hd108MethodBase(uint8_t pinClock, uint8_t pinData, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _wire(pinClock, pinData)
     {
     }
@@ -134,7 +140,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(Hd108MethodBase<T_TWOWIRE>);
     };
 

--- a/src/internal/methods/Hd108GenericMethod.h
+++ b/src/internal/methods/Hd108GenericMethod.h
@@ -43,8 +43,6 @@ public:
         _sizeData(pixelCount * elementSize + settingsSize),
         _wire(pinClock, pinData)
     {
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
     }
 
 #if !defined(__AVR_ATtiny85__) && !defined(ARDUINO_attiny)
@@ -65,15 +63,27 @@ public:
     }
 
 #if defined(ARDUINO_ARCH_ESP32)
-    void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    bool Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
         _wire.begin(sck, miso, mosi, ss);
+        return true;
     }
 #endif
 
-    void Initialize()
+    bool Initialize()
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
         _wire.begin();
+        return true;
     }
 
     void Update(bool)
@@ -114,6 +124,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(Hd108MethodBase<T_TWOWIRE>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(Hd108MethodBase<T_TWOWIRE>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/Lpd6803GenericMethod.h
+++ b/src/internal/methods/Lpd6803GenericMethod.h
@@ -36,11 +36,17 @@ License along with NeoPixel.  If not, see
 
 template<typename T_TWOWIRE> class Lpd6803MethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef typename T_TWOWIRE::SettingsObject SettingsObject;
 
     Lpd6803MethodBase(uint8_t pinClock, uint8_t pinData, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
 		_sizeFrame((pixelCount + 7) / 8), // bit for every pixel at least
 		_wire(pinClock, pinData)
     {
@@ -139,7 +145,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(Lpd6803MethodBase<T_TWOWIRE>);
     };
 

--- a/src/internal/methods/Lpd6803GenericMethod.h
+++ b/src/internal/methods/Lpd6803GenericMethod.h
@@ -44,8 +44,6 @@ public:
 		_sizeFrame((pixelCount + 7) / 8), // bit for every pixel at least
 		_wire(pinClock, pinData)
     {
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
     }
 
 #if !defined(__AVR_ATtiny85__) && !defined(ARDUINO_attiny)
@@ -67,15 +65,27 @@ public:
     }
 
 #if defined(ARDUINO_ARCH_ESP32)
-    void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    bool Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
         _wire.begin(sck, miso, mosi, ss);
+        return true;
     }
 #endif
 
-    void Initialize()
+    bool Initialize()
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
         _wire.begin();
+        return true;
     }
 
     void Update(bool)
@@ -119,6 +129,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(Lpd6803MethodBase<T_TWOWIRE>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(Lpd6803MethodBase<T_TWOWIRE>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/Lpd8806GenericMethod.h
+++ b/src/internal/methods/Lpd8806GenericMethod.h
@@ -36,11 +36,17 @@ License along with NeoPixel.  If not, see
 
 template<typename T_TWOWIRE> class Lpd8806MethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef typename T_TWOWIRE::SettingsObject SettingsObject;
 
     Lpd8806MethodBase(uint8_t pinClock, uint8_t pinData, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _sizeFrame((pixelCount + 31) / 32), 
         _wire(pinClock, pinData)
     {
@@ -139,7 +145,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(Lpd8806MethodBase<T_TWOWIRE>);
     };
 

--- a/src/internal/methods/Lpd8806GenericMethod.h
+++ b/src/internal/methods/Lpd8806GenericMethod.h
@@ -44,8 +44,6 @@ public:
         _sizeFrame((pixelCount + 31) / 32), 
         _wire(pinClock, pinData)
     {
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
     }
 
 #if !defined(__AVR_ATtiny85__) && !defined(ARDUINO_attiny)
@@ -67,15 +65,27 @@ public:
     }
 
 #if defined(ARDUINO_ARCH_ESP32)
-    void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    bool Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
         _wire.begin(sck, miso, mosi, ss);
+        return true;
     }
 #endif
 
-    void Initialize()
+    bool Initialize()
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
         _wire.begin();
+        return true;
     }
 
     void Update(bool)
@@ -119,6 +129,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(Lpd8806MethodBase<T_TWOWIRE>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(Lpd8806MethodBase<T_TWOWIRE>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/Mbi6033GenericMethod.h
+++ b/src/internal/methods/Mbi6033GenericMethod.h
@@ -45,8 +45,6 @@ public:
         _pinClock(pinClock),
         _wire(pinClock, pinData)
     {
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
     }
 
 #if !defined(__AVR_ATtiny85__) && !defined(ARDUINO_attiny)
@@ -67,16 +65,28 @@ public:
     }
 
 #if defined(ARDUINO_ARCH_ESP32)
-    void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    bool Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
         _pinClock = sck;
         _wire.begin(sck, miso, mosi, ss);
+        return true;
     }
 #endif
 
-    void Initialize()
+    bool Initialize()
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
         _wire.begin();
+        return true;
     }
 
     void Update(bool)
@@ -142,6 +152,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(Mbi6033MethodBase<T_TWOWIRE>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(Mbi6033MethodBase<T_TWOWIRE>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/Mbi6033GenericMethod.h
+++ b/src/internal/methods/Mbi6033GenericMethod.h
@@ -36,12 +36,23 @@ License along with NeoPixel.  If not, see
 
 template<typename T_TWOWIRE> class Mbi6033MethodBase
 {
+private:
+    static size_t CountChips(size_t pixelCount, size_t elementSize)
+    {
+        return NeoUtil::RoundUp(pixelCount * elementSize, c_countBytesPerChip) / c_countBytesPerChip;
+    }
+
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef typename T_TWOWIRE::SettingsObject SettingsObject;
 
     Mbi6033MethodBase(uint8_t pinClock, uint8_t pinData, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _countChips(NeoUtil::RoundUp(pixelCount * elementSize, c_countBytesPerChip) / c_countBytesPerChip),
-        _sizeData(_countChips * c_countBytesPerChip + settingsSize),
+        _countChips(CountChips(pixelCount, elementSize)),
+        _sizeData(GetBufferSize(_countChips, c_countBytesPerChip, settingsSize)),
         _pinClock(pinClock),
         _wire(pinClock, pinData)
     {
@@ -162,7 +173,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(CountChips(pixelCount, pixelSize), c_countBytesPerChip, settingsSize);
         return dataSize + sizeof(Mbi6033MethodBase<T_TWOWIRE>);
     };
 

--- a/src/internal/methods/NeoArmMethod.h
+++ b/src/internal/methods/NeoArmMethod.h
@@ -34,11 +34,17 @@ License along with NeoPixel.  If not, see
 
 template<typename T_SPEED> class NeoArmMethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
     NeoArmMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin)
     {
         pinMode(pin, OUTPUT);
@@ -124,7 +130,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(NeoArmMethodBase<T_SPEED>);
     };
 

--- a/src/internal/methods/NeoArmMethod.h
+++ b/src/internal/methods/NeoArmMethod.h
@@ -42,9 +42,6 @@ public:
         _pin(pin)
     {
         pinMode(pin, OUTPUT);
-
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
     }
 
     ~NeoArmMethodBase()
@@ -61,11 +58,18 @@ public:
         return (delta >= T_SPEED::ResetTimeUs);
     }
 
-    void Initialize()
+    bool Initialize()
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
+
         digitalWrite(_pin, LOW);
 
         _endTime = micros();
+        return true;
     }
 
     void Update(bool)
@@ -110,6 +114,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(NeoArmMethodBase<T_SPEED>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(NeoArmMethodBase<T_SPEED>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/NeoAvrMethod.h
+++ b/src/internal/methods/NeoAvrMethod.h
@@ -174,11 +174,17 @@ public:
 
 template<typename T_SPEED> class NeoAvrMethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
     NeoAvrMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin),
         _port(NULL),
         _pinMask(0)
@@ -271,7 +277,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(NeoAvrMethodBase<T_SPEED>);
     };
 

--- a/src/internal/methods/NeoAvrMethod.h
+++ b/src/internal/methods/NeoAvrMethod.h
@@ -185,9 +185,6 @@ public:
     {
         pinMode(pin, OUTPUT);
 
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
-
         _port = portOutputRegister(digitalPinToPort(pin));
         _pinMask = digitalPinToBitMask(pin);
     }
@@ -206,11 +203,18 @@ public:
         return (delta >= T_SPEED::ResetTimeUs);
     }
 
-    void Initialize()
+    bool Initialize()
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
+
         digitalWrite(_pin, LOW);
 
         _endTime = micros();
+        return true;
     }
 
     void Update(bool)
@@ -257,6 +261,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(NeoAvrMethodBase<T_SPEED>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(NeoAvrMethodBase<T_SPEED>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/NeoEsp32I2sMethod.h
+++ b/src/internal/methods/NeoEsp32I2sMethod.h
@@ -248,6 +248,7 @@ public:
         if (!_i2sBuffer)
         {
             free(_data);
+            _data = nullptr;
             return false;
         }
 

--- a/src/internal/methods/NeoEsp32I2sXMethod.h
+++ b/src/internal/methods/NeoEsp32I2sXMethod.h
@@ -831,11 +831,17 @@ template<typename T_BUSCONTEXT, typename T_BUS> T_BUSCONTEXT NeoEsp32I2sMuxBus<T
 template<typename T_SPEED, typename T_BUS, typename T_INVERT> 
 class NeoEsp32I2sXMethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
     NeoEsp32I2sXMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin),
         _bus()
     {
@@ -913,7 +919,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + T_BUS::MemorySize(dataSize) + sizeof(NeoEsp32I2sXMethodBase<T_SPEED, T_BUS, T_INVERT>);
     };
 

--- a/src/internal/methods/NeoEsp32LcdXMethod.h
+++ b/src/internal/methods/NeoEsp32LcdXMethod.h
@@ -630,11 +630,17 @@ template<typename T_BUSCONTEXT> T_BUSCONTEXT NeoEsp32LcdMuxBus<T_BUSCONTEXT>::s_
 template<typename T_SPEED, typename T_BUS, typename T_INVERT>
 class NeoEsp32LcdXMethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
     NeoEsp32LcdXMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin),
         _bus()
     {
@@ -714,7 +720,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         size_t numResetBytes = T_SPEED::ResetTimeUs / T_SPEED::ByteSendTimeUs(T_SPEED::BitSendTimeNs);
         return dataSize + T_BUS::MemorySize(dataSize + numResetBytes) + sizeof(NeoEsp32LcdXMethodBase<T_SPEED, T_BUS, T_INVERT>);
     };

--- a/src/internal/methods/NeoEsp32LcdXMethod.h
+++ b/src/internal/methods/NeoEsp32LcdXMethod.h
@@ -277,7 +277,7 @@ public:
     {
     }
 
-    void Construct(uint16_t nsBitSendTime)
+    bool Construct(uint16_t nsBitSendTime)
     {
         // construct only once on first time called
         if (_dmaItems == nullptr)
@@ -304,6 +304,7 @@ public:
             {
                 log_e("LCD Dma Table memory allocation failure (size %u)",
                     dmaBlockSize);
+                return false;
             }
             // required to init to zero as settings these below only resets some fields
             memset(_dmaItems, 0x00, dmaBlockSize); 
@@ -313,6 +314,9 @@ public:
             {
                 log_e("LCD Dma Buffer memory allocation failure (size %u)",
                     LcdBufferSize);
+                heap_caps_free(_dmaItems);
+                _dmaItems = nullptr;
+                return false;
             }
             memset(LcdBuffer, 0x00, LcdBufferSize);
 
@@ -376,14 +380,16 @@ public:
             if (clkm_div > LCD_LL_CLK_FRAC_DIV_N_MAX)
             {
                 log_e("rate is too low");
-                return;
+                Destruct();
+                return false;
             }
             else if (clkm_div < 2.0)
             {
                 log_e("rate is too fast, clkmdiv = %f (%u)",
                     clkm_div,
                     nsBitSendTime);
-                return;
+                Destruct();
+                return false;
             }
 
             // calc integer and franctional for more precise timing
@@ -443,6 +449,7 @@ public:
             gdma_tx_event_callbacks_t tx_cbs = {.on_trans_eof = dma_callback};
             gdma_register_tx_event_callbacks(_dmaChannel, &tx_cbs, NULL);
         }
+        return true;
     }
 
     void Destruct()
@@ -511,6 +518,17 @@ public:
 
         MuxMap.MarkMuxBusUpdated(muxId);
     }
+
+    size_t MemorySize() const
+    {
+        return ((LcdBufferSize + DMA_DESCRIPTOR_BUFFER_MAX_SIZE - 1) / DMA_DESCRIPTOR_BUFFER_MAX_SIZE + 1) * sizeof(dma_descriptor_t) + LcdBufferSize + sizeof(NeoEspLcdMonoBuffContext<T_MUXMAP>) + sizeof(T_MUXMAP);
+    };
+
+    static size_t MemorySize(size_t dataSize)
+    {
+        dataSize *= (8 * T_MUXMAP::DmaBitsPerPixelBit * T_MUXMAP::MuxBusDataSize);
+        return ((dataSize + DMA_DESCRIPTOR_BUFFER_MAX_SIZE - 1) / DMA_DESCRIPTOR_BUFFER_MAX_SIZE + 1) * sizeof(dma_descriptor_t) + dataSize + sizeof(NeoEspLcdMonoBuffContext<T_MUXMAP>);
+    };
 };
 
 //
@@ -536,14 +554,18 @@ public:
         _muxId = s_context.MuxMap.RegisterNewMuxBus(dataSize);
     }
 
-    void Initialize(uint8_t pin, uint16_t nsBitSendTime, bool invert)
+    bool Initialize(uint8_t pin, uint16_t nsBitSendTime, bool invert)
     {
-        s_context.Construct(nsBitSendTime);
+        if (!s_context.Construct(nsBitSendTime))
+        {
+            return false;
+        }
         
         uint8_t muxIdx = LCD_DATA_OUT0_IDX + _muxId;
         esp_rom_gpio_connect_out_signal(pin, muxIdx, invert, false);
         gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[pin], PIN_FUNC_GPIO);
         gpio_set_drive_capability((gpio_num_t)pin, (gpio_drive_cap_t)3);
+        return true;
     }
 
     void DeregisterMuxBus(uint8_t pin)
@@ -579,6 +601,16 @@ public:
     void MarkUpdated()
     {
         s_context.MuxMap.MarkMuxBusUpdated(_muxId);
+    }
+
+    size_t MemorySize() const
+    {
+        return s_context.MemorySize();
+    }
+
+    static size_t MemorySize(size_t dataSize)
+    {
+        return T_BUSCONTEXT::MemorySize(dataSize);
     }
 
 private:
@@ -627,16 +659,21 @@ public:
         return _bus.IsWriteDone();
     }
 
-    void Initialize()
+    bool Initialize()
     {
-        _bus.Initialize(_pin, T_SPEED::BitSendTimeNs, T_INVERT::Inverted);
+        if (!_bus.Initialize(_pin, T_SPEED::BitSendTimeNs, T_INVERT::Inverted))
+        {
+            return false;
+        }
 
         _data = static_cast<uint8_t*>(malloc(_sizeData));
         if (_data == nullptr)
         {
             log_e("front buffer memory allocation failure");
+            _bus.DeregisterMuxBus(_pin);
+            return false;
         }
-        // data cleared later in Begin()
+        return true;
     }
 
     void Update(bool)
@@ -668,6 +705,19 @@ public:
     {
         return _sizeData;
     }
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + _bus.MemorySize() + sizeof(NeoEsp32LcdXMethodBase<T_SPEED, T_BUS, T_INVERT>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t numResetBytes = T_SPEED::ResetTimeUs / T_SPEED::ByteSendTimeUs(T_SPEED::BitSendTimeNs);
+        return dataSize + T_BUS::MemorySize(dataSize + numResetBytes) + sizeof(NeoEsp32LcdXMethodBase<T_SPEED, T_BUS, T_INVERT>);
+    };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)
     {

--- a/src/internal/methods/NeoEsp32RmtMethod.h
+++ b/src/internal/methods/NeoEsp32RmtMethod.h
@@ -615,6 +615,7 @@ public:
         if (!_dataSending)
         {
             free(_dataEditing);
+            _dataEditing = nullptr;
             return false;
         }
 

--- a/src/internal/methods/NeoEsp32RmtMethod.h
+++ b/src/internal/methods/NeoEsp32RmtMethod.h
@@ -561,17 +561,23 @@ public:
 
 template<typename T_SPEED, typename T_CHANNEL> class NeoEsp32RmtMethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
     NeoEsp32RmtMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize)  :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin)
     {
     }
 
     NeoEsp32RmtMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize, NeoBusChannel channel) :
-        _sizeData(pixelCount* elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin),
         _channel(channel)
     {
@@ -687,7 +693,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return 2 * dataSize + sizeof(NeoEsp32RmtMethodBase<T_SPEED, T_CHANNEL>);
     };
 

--- a/src/internal/methods/NeoEsp8266DmaMethod.h
+++ b/src/internal/methods/NeoEsp8266DmaMethod.h
@@ -185,12 +185,18 @@ public:
 
 template<typename T_ENCODER, typename T_SPEED> class NeoEsp8266DmaMethodBase : NeoEsp8266I2sMethodCore
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
     NeoEsp8266DmaMethodBase(uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
         _sizePixel(elementSize),
-        _sizeData(pixelCount * elementSize + settingsSize)
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize))
     {
         size_t dmaPixelSize = T_ENCODER::DmaBitsPerPixelBit * T_ENCODER::SpacingPixelSize(_sizePixel);
         size_t dmaSettingsSize = T_ENCODER::DmaBitsPerPixelBit * settingsSize;
@@ -320,7 +326,7 @@ public:
         i2sResetSize = NeoUtil::RoundUp(i2sResetSize, c_I2sByteBoundarySize);
         size_t is2BufMaxBlockSize = (c_maxDmaBlockSize / dmaPixelSize) * dmaPixelSize;
 
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + NeoEsp8266I2sMethodCore::getI2sBuffersSize(i2sBufferSize, i2sResetSize, is2BufMaxBlockSize) + sizeof(NeoEsp8266DmaMethodBase<T_ENCODER, T_SPEED>) ;
     };
 

--- a/src/internal/methods/NeoEsp8266DmaMethod.h
+++ b/src/internal/methods/NeoEsp8266DmaMethod.h
@@ -257,6 +257,7 @@ public:
         if (!AllocateI2s(T_ENCODER::IdleLevel))
         {
             free(_data);
+            _data = nullptr;
             return false;
         }
 

--- a/src/internal/methods/NeoEsp8266DmaMethod.h
+++ b/src/internal/methods/NeoEsp8266DmaMethod.h
@@ -205,10 +205,7 @@ public:
         i2sResetSize = NeoUtil::RoundUp(i2sResetSize, c_I2sByteBoundarySize);
         size_t is2BufMaxBlockSize = (c_maxDmaBlockSize / dmaPixelSize) * dmaPixelSize;
 
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
-
-        AllocateI2s(i2sBufferSize, i2sResetSize, is2BufMaxBlockSize, T_ENCODER::IdleLevel);
+        ConstructI2s(i2sBufferSize, i2sResetSize, is2BufMaxBlockSize, T_ENCODER::IdleLevel);
     }
 
     NeoEsp8266DmaMethodBase([[maybe_unused]] uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize) : 
@@ -243,9 +240,21 @@ public:
         return IsIdle();
     }
 
-    void Initialize()
+    bool Initialize()
     {
-        uint8_t i2sBaseClockDivisor; 
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data)
+        {
+            return false;
+        }
+
+        if (!AllocateI2s(T_ENCODER::IdleLevel))
+        {
+            free(_data);
+            return false;
+        }
+
+        uint8_t i2sBaseClockDivisor;
         uint8_t i2sClockDivisor;
 
         FindBestClockDivisors(&i2sClockDivisor, 
@@ -254,6 +263,7 @@ public:
             T_ENCODER::DmaBitsPerPixelBit);
 
         InitializeI2s(i2sClockDivisor, i2sBaseClockDivisor);
+        return true;
     }
 
     void IRAM_ATTR Update(bool)
@@ -288,6 +298,31 @@ public:
     {
         return _sizeData;
     }
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + getI2sBuffersSize() + sizeof(NeoEsp8266DmaMethodBase<T_ENCODER, T_SPEED>) ;
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dmaPixelSize = T_ENCODER::DmaBitsPerPixelBit * T_ENCODER::SpacingPixelSize(pixelSize);
+        size_t dmaSettingsSize = T_ENCODER::DmaBitsPerPixelBit * settingsSize;
+
+        size_t i2sBufferSize = pixelCount * dmaPixelSize + dmaSettingsSize;
+        // size is rounded up to nearest c_I2sByteBoundarySize
+        i2sBufferSize = NeoUtil::RoundUp(i2sBufferSize, c_I2sByteBoundarySize);
+
+        // calculate a buffer size that takes reset amount of time
+        size_t i2sResetSize = T_SPEED::ResetTimeUs * T_ENCODER::DmaBitsPerPixelBit / T_SPEED::ByteSendTimeUs(T_SPEED::BitSendTimeNs);
+        // size is rounded up to nearest c_I2sByteBoundarySize
+        i2sResetSize = NeoUtil::RoundUp(i2sResetSize, c_I2sByteBoundarySize);
+        size_t is2BufMaxBlockSize = (c_maxDmaBlockSize / dmaPixelSize) * dmaPixelSize;
+
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + NeoEsp8266I2sMethodCore::getI2sBuffersSize(i2sBufferSize, i2sResetSize, is2BufMaxBlockSize) + sizeof(NeoEsp8266DmaMethodBase<T_ENCODER, T_SPEED>) ;
+    };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)
     {

--- a/src/internal/methods/NeoEsp8266I2sDmx512Method.h
+++ b/src/internal/methods/NeoEsp8266I2sDmx512Method.h
@@ -203,6 +203,7 @@ public:
         if (!AllocateI2s(T_SPEED::MtbpLevel))
         {
             free(_data);
+            _data = nullptr;
             return false;
         }
         // first "slot" cleared due to protocol requiring it to be zero

--- a/src/internal/methods/NeoEsp8266I2sDmx512Method.h
+++ b/src/internal/methods/NeoEsp8266I2sDmx512Method.h
@@ -128,11 +128,17 @@ public:
 
 template<typename T_SPEED> class NeoEsp8266I2sDmx512MethodBase : NeoEsp8266I2sMethodCore
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize + T_SPEED::HeaderSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
     NeoEsp8266I2sDmx512MethodBase(uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize + T_SPEED::HeaderSize)
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize))
     {
         size_t dmaPixelBits = I2sBitsPerPixelBytes * elementSize;
         size_t dmaSettingsBits = I2sBitsPerPixelBytes * (settingsSize + T_SPEED::HeaderSize);
@@ -264,7 +270,7 @@ public:
         // protocol limits use of full block size to c_I2sByteBoundarySize
         size_t is2BufMaxBlockSize = (c_maxDmaBlockSize / c_I2sByteBoundarySize) * c_I2sByteBoundarySize;
 
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + NeoEsp8266I2sMethodCore::getI2sBuffersSize(i2sBufferSize, i2sResetSize, is2BufMaxBlockSize) + sizeof(NeoEsp8266I2sDmx512MethodBase<T_SPEED>) ;
     };
 

--- a/src/internal/methods/NeoEsp8266UartMethod.h
+++ b/src/internal/methods/NeoEsp8266UartMethod.h
@@ -145,8 +145,13 @@ protected:
     uint8_t* _data;        // Holds LED color values
     uint32_t _startTime;     // Microsecond count when last update started
 
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
     NeoEsp8266UartBase(uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize)
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize))
     {
     }
 
@@ -229,7 +234,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = NeoEsp8266UartBase::GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(NeoEsp8266Uart<T_UARTFEATURE, T_UARTCONTEXT>);
     };
 
@@ -326,7 +331,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = NeoEsp8266UartBase::GetBufferSize(pixelCount, pixelSize, settingsSize);
         return 2 * dataSize + sizeof(NeoEsp8266AsyncUart<T_UARTFEATURE, T_UARTCONTEXT>);
     };
 

--- a/src/internal/methods/NeoEspBitBangMethod.h
+++ b/src/internal/methods/NeoEspBitBangMethod.h
@@ -190,12 +190,18 @@ public:
 
 template<typename T_SPEED, typename T_INVERTED, bool V_INTER_PIXEL_ISR> class NeoEspBitBangMethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
     NeoEspBitBangMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
         _sizePixel(elementSize),
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin)
     {
         pinMode(pin, OUTPUT);
@@ -288,7 +294,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(NeoEspBitBangMethodBase<T_SPEED, T_INVERTED, V_INTER_PIXEL_ISR>);
     };
 

--- a/src/internal/methods/NeoEspBitBangMethod.h
+++ b/src/internal/methods/NeoEspBitBangMethod.h
@@ -199,9 +199,6 @@ public:
         _pin(pin)
     {
         pinMode(pin, OUTPUT);
-
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
     }
 
     ~NeoEspBitBangMethodBase()
@@ -218,11 +215,17 @@ public:
         return (delta >= T_SPEED::ResetTimeUs);
     }
 
-    void Initialize()
+    bool Initialize()
     {
         digitalWrite(_pin, T_INVERTED::IdleLevel);
 
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data) {
+            return false;
+        }       
+
         _endTime = micros();
+        return true;
     }
 
     void Update(bool)
@@ -275,6 +278,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(NeoEspBitBangMethodBase<T_SPEED, T_INVERTED, V_INTER_PIXEL_ISR>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(NeoEspBitBangMethodBase<T_SPEED, T_INVERTED, V_INTER_PIXEL_ISR>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/NeoNrf52xMethod.h
+++ b/src/internal/methods/NeoNrf52xMethod.h
@@ -356,17 +356,23 @@ protected:
 
 template<typename T_SPEED, typename T_BUS> class NeoNrf52xMethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
     NeoNrf52xMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin)
     {
     }
 
     NeoNrf52xMethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize, NeoBusChannel channel) :
-        _sizeData(pixelCount* elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin),
         _bus(channel)
     {
@@ -456,7 +462,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + _dmaBufferSize + sizeof(NeoNrf52xMethodBase<T_SPEED, T_BUS>);
     };
 

--- a/src/internal/methods/P9813GenericMethod.h
+++ b/src/internal/methods/P9813GenericMethod.h
@@ -36,11 +36,17 @@ License along with NeoPixel.  If not, see
 
 template<typename T_TWOWIRE> class P9813MethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef typename T_TWOWIRE::SettingsObject SettingsObject;
 
     P9813MethodBase(uint8_t pinClock, uint8_t pinData, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _sizeEndFrame((pixelCount + 15) / 16), // 16 = div 2 (bit for every two pixels) div 8 (bits to bytes)
         _wire(pinClock, pinData)
     {
@@ -133,7 +139,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(P9813MethodBase<T_TWOWIRE>);
     };
 

--- a/src/internal/methods/P9813GenericMethod.h
+++ b/src/internal/methods/P9813GenericMethod.h
@@ -44,8 +44,6 @@ public:
         _sizeEndFrame((pixelCount + 15) / 16), // 16 = div 2 (bit for every two pixels) div 8 (bits to bytes)
         _wire(pinClock, pinData)
     {
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
     }
 
 #if !defined(__AVR_ATtiny85__) && !defined(ARDUINO_attiny)
@@ -66,15 +64,25 @@ public:
     }
 
 #if defined(ARDUINO_ARCH_ESP32)
-    void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    bool Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data) {
+            return false;
+        }
         _wire.begin(sck, miso, mosi, ss);
+        return true;
     }
 #endif
 
-    void Initialize()
+    bool Initialize()
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data) {
+            return false;
+        }
         _wire.begin();
+        return true;
     }
 
     void Update(bool)
@@ -115,6 +123,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(P9813MethodBase<T_TWOWIRE>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(P9813MethodBase<T_TWOWIRE>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/PixieStreamMethod.h
+++ b/src/internal/methods/PixieStreamMethod.h
@@ -37,6 +37,12 @@ License along with NeoPixel.  If not, see
 
 class PixieStreamMethod
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
@@ -44,7 +50,7 @@ public:
             size_t elementSize, 
             size_t settingsSize, 
             Stream* pixieStream) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _stream(pixieStream),
         _usEndTime(0)
     {
@@ -111,7 +117,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(PixieStreamMethod);
     };
 

--- a/src/internal/methods/PixieStreamMethod.h
+++ b/src/internal/methods/PixieStreamMethod.h
@@ -48,8 +48,6 @@ public:
         _stream(pixieStream),
         _usEndTime(0)
     {
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
     }
 
     ~PixieStreamMethod()
@@ -63,9 +61,13 @@ public:
         return (micros() - _usEndTime) > 1000L; // ensure 1ms delay between calls
     }
 
-    void Initialize()
+    bool Initialize()
     {
-        // nothing to initialize, UART is managed outside this library
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data) {
+            return false;
+        }
+        return true;
     }
 
     void Update(bool)
@@ -99,6 +101,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(PixieStreamMethod);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(PixieStreamMethod);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/Rp2040/NeoRp2040x4Method.h
+++ b/src/internal/methods/Rp2040/NeoRp2040x4Method.h
@@ -50,18 +50,24 @@ template<typename T_SPEED,
         uint V_IRQ_INDEX = 1> 
 class NeoRp2040x4MethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef NeoNoSettings SettingsObject;
 
     NeoRp2040x4MethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize)  :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin),
         _mergedFifoCount((_pio.Instance->dbg_cfginfo & PIO_DBG_CFGINFO_FIFO_DEPTH_BITS) * 2) // merged TX / RX FIFO buffer in words
     {
     }
 
     NeoRp2040x4MethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize, NeoBusChannel channel) :
-        _sizeData(pixelCount* elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _pin(pin),
         _pio(channel),
         _mergedFifoCount((_pio.Instance->dbg_cfginfo& PIO_DBG_CFGINFO_FIFO_DEPTH_BITS) * 2) // merged TX / RX FIFO buffer in words
@@ -297,7 +303,7 @@ Serial.println();
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return 2 * dataSize + sizeof(NeoRp2040x4MethodBase<T_SPEED, T_PIO_INSTANCE, V_INVERT, V_IRQ_INDEX>) + sizeof(NeoRp2040DmaState<V_IRQ_INDEX>);
     };
 

--- a/src/internal/methods/Rp2040/NeoRp2040x4Method.h
+++ b/src/internal/methods/Rp2040/NeoRp2040x4Method.h
@@ -58,7 +58,6 @@ public:
         _pin(pin),
         _mergedFifoCount((_pio.Instance->dbg_cfginfo & PIO_DBG_CFGINFO_FIFO_DEPTH_BITS) * 2) // merged TX / RX FIFO buffer in words
     {
-        construct();
     }
 
     NeoRp2040x4MethodBase(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize, NeoBusChannel channel) :
@@ -67,7 +66,6 @@ public:
         _pio(channel),
         _mergedFifoCount((_pio.Instance->dbg_cfginfo& PIO_DBG_CFGINFO_FIFO_DEPTH_BITS) * 2) // merged TX / RX FIFO buffer in words
     {
-        construct();
     }
 
     ~NeoRp2040x4MethodBase()
@@ -106,8 +104,10 @@ public:
         return _dmaState.IsReadyToSend(T_SPEED::ResetTimeUs + _fifoCacheEmptyDelta);
     }
 
-    void Initialize()
+    bool Initialize()
     {
+        if (!construct()) return false;
+
         // Select the largest FIFO fetch size that aligns with our data size
         // BUT, since RP2040 is little endian, if the source element size is
         // 8 bits, then the larger shift bits accounts for endianess
@@ -236,6 +236,8 @@ Serial.println();
             false);
 
         dma_irqn_set_channel_enabled(V_IRQ_INDEX, _dmaChannel, true);
+
+        return true;
     }
 
     void Update(bool maintainBufferConsistency)
@@ -287,6 +289,18 @@ Serial.println();
         return _sizeData;
     }
 
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return 2 * dataSize + sizeof(NeoRp2040x4MethodBase<T_SPEED, T_PIO_INSTANCE, V_INVERT, V_IRQ_INDEX>) + sizeof(NeoRp2040DmaState<V_IRQ_INDEX>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return 2 * dataSize + sizeof(NeoRp2040x4MethodBase<T_SPEED, T_PIO_INSTANCE, V_INVERT, V_IRQ_INDEX>) + sizeof(NeoRp2040DmaState<V_IRQ_INDEX>);
+    };
+
     void applySettings([[maybe_unused]] const SettingsObject& settings)
     {
     }
@@ -308,13 +322,19 @@ private:
     int _sm;
     int _dmaChannel;
 
-    void construct()
+    bool construct()
     {
         _dataEditing = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin() with a ClearTo(0)
-
+        if (!_dataEditing) {
+            return false;
+        }
         _dataSending = static_cast<uint8_t*>(malloc(_sizeData));
-        // no need to initialize it, it gets overwritten on every send
+        if (!_dataSending) {
+            free(_dataEditing);
+            _dataEditing = nullptr;
+            return false;
+        }
+        return true;
     }
 };
 

--- a/src/internal/methods/Sm16716GenericMethod.h
+++ b/src/internal/methods/Sm16716GenericMethod.h
@@ -37,11 +37,17 @@ License along with NeoPixel.  If not, see
 
 template<typename T_TWOWIRE> class Sm16716MethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef typename T_TWOWIRE::SettingsObject SettingsObject;
 
     Sm16716MethodBase(uint8_t pinClock, uint8_t pinData, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount* elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _sizeFrame(6), // 48 bits
         _wire(pinClock, pinData)
     {
@@ -135,7 +141,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(Sm16716MethodBase<T_TWOWIRE>);
     };
 

--- a/src/internal/methods/Sm16716GenericMethod.h
+++ b/src/internal/methods/Sm16716GenericMethod.h
@@ -45,8 +45,6 @@ public:
         _sizeFrame(6), // 48 bits
         _wire(pinClock, pinData)
     {
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        memset(_data, 0, _sizeData);
     }
 
 #if !defined(__AVR_ATtiny85__) && !defined(ARDUINO_attiny)
@@ -68,15 +66,20 @@ public:
 
 #if defined(ARDUINO_ARCH_ESP32)
     // can't support hardware SPI due to weird extra bits
-    //void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    //bool Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     //{
     //    _wire.begin(sck, miso, mosi, ss);
     //}
 #endif
 
-    void Initialize()
+    bool Initialize()
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data) {
+            return false;
+        }
         _wire.begin();
+        return true;
     }
 
     void Update(bool)
@@ -122,6 +125,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(Sm16716MethodBase<T_TWOWIRE>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(Sm16716MethodBase<T_TWOWIRE>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)

--- a/src/internal/methods/Tlc5947GenericMethod.h
+++ b/src/internal/methods/Tlc5947GenericMethod.h
@@ -79,6 +79,18 @@ public:
 
 template<typename T_BITCONVERT, typename T_TWOWIRE> class Tlc5947MethodBase
 {
+private:
+    static size_t CountModule(size_t pixelCount, size_t elementSize)
+    {
+        return (pixelCount * elementSize + TLC5947_MODULE_PWM_CHANNEL_COUNT - 1) / TLC5947_MODULE_PWM_CHANNEL_COUNT;
+    }
+
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef typename T_TWOWIRE::SettingsObject SettingsObject;
 
@@ -86,8 +98,8 @@ public:
     static const size_t sizeSendBuffer = 36;
 
     Tlc5947MethodBase(uint8_t pinClock, uint8_t pinData, uint8_t pinLatch, uint8_t pinOutputEnable, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _countModule((pixelCount * elementSize + TLC5947_MODULE_PWM_CHANNEL_COUNT - 1) / TLC5947_MODULE_PWM_CHANNEL_COUNT),
-        _sizeData(_countModule * TLC5947_MODULE_PWM_CHANNEL_COUNT + settingsSize),
+        _countModule(CountModule(pixelCount, elementSize)),
+        _sizeData(GetBufferSize(_countModule, TLC5947_MODULE_PWM_CHANNEL_COUNT, settingsSize)),
         _wire(pinClock, pinData),
         _pinLatch(pinLatch),
         _pinOutputEnable(pinOutputEnable)
@@ -201,7 +213,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = ((pixelCount * pixelSize + TLC5947_MODULE_PWM_CHANNEL_COUNT - 1) / TLC5947_MODULE_PWM_CHANNEL_COUNT) * TLC5947_MODULE_PWM_CHANNEL_COUNT + settingsSize;
+        size_t dataSize = GetBufferSize(CountModule(pixelCount, pixelSize), TLC5947_MODULE_PWM_CHANNEL_COUNT, settingsSize);
         return dataSize + sizeof(Tlc5947MethodBase<T_BITCONVERT, T_TWOWIRE>);
     };
 

--- a/src/internal/methods/Tlc59711GenericMethod.h
+++ b/src/internal/methods/Tlc59711GenericMethod.h
@@ -51,6 +51,12 @@ public:
 template <typename T_TWOWIRE> 
 class Tlc59711MethodBase
 {
+    private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return NeoUtil::RoundUp(pixelCount * elementSize, Tlc69711Settings::c_dataPerChipSize) + settingsSize;
+    }
+
 public:
     typedef typename T_TWOWIRE::SettingsObject SettingsObject;
 
@@ -59,7 +65,7 @@ public:
             uint16_t pixelCount, 
             size_t elementSize, 
             size_t settingsSize) :
-        _sizeData(NeoUtil::RoundUp(pixelCount * elementSize, Tlc69711Settings::c_dataPerChipSize) + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _wire(pinClock, pinData)
     {
     }
@@ -188,7 +194,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = NeoUtil::RoundUp(pixelCount * pixelSize, Tlc69711Settings::c_dataPerChipSize) + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(Tlc59711MethodBase<T_TWOWIRE>);
     };
 

--- a/src/internal/methods/Ws2801GenericMethod.h
+++ b/src/internal/methods/Ws2801GenericMethod.h
@@ -36,11 +36,17 @@ License along with NeoPixel.  If not, see
 
 template<typename T_TWOWIRE> class Ws2801MethodBase
 {
+private:
+    static size_t GetBufferSize(uint16_t pixelCount, size_t elementSize, size_t settingsSize)
+    {
+        return pixelCount * elementSize + settingsSize;
+    }
+
 public:
     typedef typename T_TWOWIRE::SettingsObject SettingsObject;
 
     Ws2801MethodBase(uint8_t pinClock, uint8_t pinData, uint16_t pixelCount, size_t elementSize, size_t settingsSize) :
-        _sizeData(pixelCount * elementSize + settingsSize),
+        _sizeData(GetBufferSize(pixelCount, elementSize, settingsSize)),
         _wire(pinClock, pinData)
     {
     }
@@ -139,7 +145,7 @@ public:
 
     static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
     {
-        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        size_t dataSize = GetBufferSize(pixelCount, pixelSize, settingsSize);
         return dataSize + sizeof(Ws2801MethodBase<T_TWOWIRE>);
     };
 

--- a/src/internal/methods/Ws2801GenericMethod.h
+++ b/src/internal/methods/Ws2801GenericMethod.h
@@ -43,8 +43,6 @@ public:
         _sizeData(pixelCount * elementSize + settingsSize),
         _wire(pinClock, pinData)
     {
-        _data = static_cast<uint8_t*>(malloc(_sizeData));
-        // data cleared later in Begin()
     }
 
 #if !defined(__AVR_ATtiny85__) && !defined(ARDUINO_attiny)
@@ -67,19 +65,29 @@ public:
     }
 
 #if defined(ARDUINO_ARCH_ESP32)
-    void Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
+    bool Initialize(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data) {
+            return false;
+        }
         _wire.begin(sck, miso, mosi, ss);
 
         _endTime = micros();
+        return true;
     }
 #endif
 
-    void Initialize()
+    bool Initialize()
     {
+        _data = static_cast<uint8_t*>(malloc(_sizeData));
+        if (!_data) {
+            return false;
+        }
         _wire.begin();
 
         _endTime = micros();
+        return true;
     }
 
     void Update(bool)
@@ -121,6 +129,18 @@ public:
     size_t getDataSize() const
     {
         return _sizeData;
+    };
+
+    size_t MemorySize() const
+    {
+        size_t dataSize = _sizeData;
+        return dataSize + sizeof(Ws2801MethodBase<T_TWOWIRE>);
+    };
+
+    static size_t MemorySize(size_t pixelCount, size_t pixelSize, size_t settingsSize = 0)
+    {
+        size_t dataSize = pixelCount * pixelSize + settingsSize;
+        return dataSize + sizeof(Ws2801MethodBase<T_TWOWIRE>);
     };
 
     void applySettings([[maybe_unused]] const SettingsObject& settings)


### PR DESCRIPTION
- Postpone memory allocations until Initialize() is called (created bus does no malloc() in constructor).
- Add IsValid() method to prevent issues with unallocated buffers (calls without preceding Begin() or if malloc() failed).
- Add success return value to Begin()/Initialize() (to check if bus initialization was successful)
- Implement MemorySize() methods to retrieve bus memory footprint (estimate and actual)
- Add clearing of secondary buffer (edit/transmit) to avoid flashing of uninitialized LEDs (supersedes #905)

Closes #870 