### PR TITLE
Use ClearTo(0) for transmit buffers if they exist.

### DIFF
--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -105,7 +105,10 @@ public:
     {
         _method.Initialize();
         ClearTo(0);
-        if (_method.SwapBuffers()) ClearTo(0);
+        if (_method.SwapBuffers())
+        {
+            ClearTo(0);
+        }
     }
 
     // used by DotStarSpiMethod/DotStarEsp32DmaSpiMethod if pins can be configured
@@ -113,7 +116,10 @@ public:
     {
         _method.Initialize(sck, miso, mosi, ss);
         ClearTo(0);
-        if (_method.SwapBuffers()) ClearTo(0);
+        if (_method.SwapBuffers())
+        {
+            ClearTo(0);
+        }
     }
 
     // used by DotStarEsp32DmaSpiMethod if pins can be configured - reordered and extended version supporting quad SPI
@@ -121,7 +127,10 @@ public:
     {
         _method.Initialize(sck, dat0, dat1, dat2, dat3, ss);
         ClearTo(0);
-        if (_method.SwapBuffers()) ClearTo(0);
+        if (_method.SwapBuffers())
+        {
+            ClearTo(0);
+        }
     }
 
     // used by DotStarEsp32DmaSpiMethod if pins can be configured - reordered and extended version supporting oct SPI
@@ -129,7 +138,10 @@ public:
     {
         _method.Initialize(sck, dat0, dat1, dat2, dat3, dat4, dat5, dat6, dat7, ss);
         ClearTo(0);
-        if (_method.SwapBuffers()) ClearTo(0);
+        if (_method.SwapBuffers())
+        {
+            ClearTo(0);
+        }
     }
 
     void Show(bool maintainBufferConsistency = true)


### PR DESCRIPTION
Some methods use secondary/transmit buffers which remain uncleared during creation.
This sometimes leads to pixels containing random data if *show* method is called with inconsistent parameter (i.e. `Show(false)`) and not all pixels are updated using `SetPixelColor()`.

This PR aims to clear secondary buffers if they exist.

Part of #906 that fixes #904.