### PR TITLE
Implement coryking c0f7ec8 commit.

### DIFF
--- a/src/internal/methods/NeoEsp32LcdXMethod.h
+++ b/src/internal/methods/NeoEsp32LcdXMethod.h
@@ -552,7 +552,11 @@ public:
         
         uint8_t muxIdx = LCD_DATA_OUT0_IDX + _muxId;
         esp_rom_gpio_connect_out_signal(pin, muxIdx, invert, false);
-        gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[pin], PIN_FUNC_GPIO);
+        #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+            gpio_iomux_out(pin, PIN_FUNC_GPIO, false);
+        #else
+            gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[pin], PIN_FUNC_GPIO);
+        #endif
         gpio_set_drive_capability((gpio_num_t)pin, (gpio_drive_cap_t)3);
         return true;
     }


### PR DESCRIPTION
Submitting this as a PR to hopefully get it committed.

Replace deprecated `gpio_hal_iomux_func_sel()` with `gpio_iomux_out()` for ESP-IDF 5.5+.

- ESP-IDF 5.5.0 removed `gpio_hal_iomux_func_sel()`.
- Use `gpio_iomux_out()` for ESP-IDF 5.5+.
- Maintain backward compatibility with `#ifdef` for older versions.
- Fixes compilation error with pioarduino platform (ESP-IDF 5.5.1).

Tested with:
- pioarduino platform (ESP-IDF 5.5.1, Arduino Core 3.3.4).
- ESP32-S3 boards (Lolin S3 Mini, Seeed XIAO ESP32S3).

Resolves: Makuna#895